### PR TITLE
Use parameterized queries in Python database layer

### DIFF
--- a/python/src/block_manager.py
+++ b/python/src/block_manager.py
@@ -75,7 +75,7 @@ class BlockManager:
         This reads a block without accessing the blockfile.
         As the blockfile can be large and expensive to read.
         """
-        retval = database.query(f"SELECT * FROM blocks WHERE hash = '{hash}';")
+        retval = database.query("SELECT * FROM blocks WHERE hash = %s;", (hash,))
         return self._results_to_block(retval)
 
     def _read_block_from_height(self, height) -> Optional[Dict[str, Any]]:
@@ -83,12 +83,15 @@ class BlockManager:
         This reads a block without accessing the blockfile.
         As the blockfile can be large and expensive to read.
         """
-        retval = database.query(f"SELECT * FROM blocks WHERE height = '{height}';")
+        retval = database.query("SELECT * FROM blocks WHERE height = %s;", (height,))
         return self._results_to_block(retval)
 
     def _read_tx_at_height(self, height) -> List[str]:
         try:
-            result = database.query(f"SELECT hash FROM tx WHERE height = '{height}' ORDER BY blockindex ASC;")
+            result = database.query(
+                "SELECT hash FROM tx WHERE height = %s ORDER BY blockindex ASC;",
+                (height,),
+            )
             return [x[0] for x in result]
         except ProgrammingError as e:
             print(f"MySQL ProgrammingError {e}")

--- a/python/src/collection.py
+++ b/python/src/collection.py
@@ -66,7 +66,7 @@ class Collection:
 
     def get_tx_as_hex(self, hash: str) -> List[Any]:
         # Read tx from database
-        return database.query(f"SELECT tx FROM collection WHERE hash = '{hash}';")
+        return database.query("SELECT tx FROM collection WHERE hash = %s;", (hash,))
 
     def is_valid_collection(self, cname: str) -> bool:
         return cname in self.static_names or cname in self.dynamic_names
@@ -74,7 +74,10 @@ class Collection:
     def get_collection_contents(self, monitor_name: str) -> List[Any]:
         """ Return the collection hashes associated with this collection name """
         assert self.is_valid_collection(monitor_name)
-        return database.query(f"SELECT hash FROM collection WHERE name = '{monitor_name}';")
+        return database.query(
+            "SELECT hash FROM collection WHERE name = %s;",
+            (monitor_name,),
+        )
 
     def add_monitor(self, monitor: Monitor):
         assert not self.is_valid_collection(monitor.name)

--- a/python/src/database.py
+++ b/python/src/database.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Optional, Sequence
 
 from mysql.connector import connect
 from config import ConfigType
@@ -18,16 +18,19 @@ class Database:
         self.password = config[network]["password"]
         self.database = config[network]["database"]
 
-    def query(self, query_string: str) -> List[Any]:
+    def query(
+        self,
+        query_string: str,
+        params: Optional[Sequence[Any]] = None,
+    ) -> List[Any]:
         with connect(
             host=self.host,
             user=self.user,
             password=self.password,
             database=self.database,
         ) as connection:
-            query = (query_string)
             cursor = connection.cursor()
-            cursor.execute(query)
+            cursor.execute(query_string, params or ())
             retval = list(cursor.fetchall())
             connection.commit()
             cursor.close()

--- a/python/src/tools/fix_block_file.py
+++ b/python/src/tools/fix_block_file.py
@@ -69,10 +69,9 @@ def main():
 
     for hash in zero_offset_blocks:
         offset = hash_to_offset[hash]
-        query = f"UPDATE blocks SET `offset`={offset} WHERE hash='{hash}';"
-        # query = f"replace blocks where hash = '{hash}' (offset) VALUES ({offset});"
-        print(query)
-        r = database.query(query)
+        query = "UPDATE blocks SET `offset` = %s WHERE hash = %s;"
+        print(query, offset, hash)
+        r = database.query(query, (offset, hash))
         print(r)
 
 

--- a/python/src/tools/fix_height_block_table.py
+++ b/python/src/tools/fix_height_block_table.py
@@ -6,8 +6,12 @@ sys.path.append('..')
 from database import database
 from config import load_config, ConfigType
 
+ALLOWED_TABLES = frozenset({"blocks", "utxo", "tx"})
+
 
 def get_max_height(table_name: str) -> int:
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table_name}")
     retval = database.query(f"SELECT max(height) FROM {table_name};")
     result = list(map(lambda x: x[0], retval))[0]
     return int(result)
@@ -31,12 +35,14 @@ def main():
     # table_name = "blocks"
     # table_name = "utxo"
     table_name = "tx"
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table_name}")
     max_height = get_max_height(table_name)
     print(f"max_height = {max_height}")
 
     for i in range(7050, max_height + 1):
-        query = f"UPDATE {table_name} SET height={i + start_height + 1} WHERE height='{i}';"
-        r = database.query(query)
+        query = f"UPDATE {table_name} SET height = %s WHERE height = %s;"
+        r = database.query(query, (i + start_height + 1, i))
         print(r)
 
 

--- a/python/src/tx_analyser.py
+++ b/python/src/tx_analyser.py
@@ -34,7 +34,7 @@ class TxAnalyser:
 
     def _read_utxo(self, hash: str) -> List[Dict[str, Any]]:
         # Read utxo from database
-        result = database.query(f"SELECT * FROM utxo WHERE hash = '{hash}';")
+        result = database.query("SELECT * FROM utxo WHERE hash = %s;", (hash,))
         retval = [{
             "hash": f"{x[0]}", "pos": x[1], "satoshi": x[2],
             "height": x[3]
@@ -49,13 +49,19 @@ class TxAnalyser:
 
     def get_utxo_by_outpoint(self, hash: str, pos: int) -> Dict[str, Any]:
         # Read utxo from database
-        result = database.query(f"SELECT * FROM utxo WHERE hash = '{hash}' AND pos = {pos};")
+        result = database.query(
+            "SELECT * FROM utxo WHERE hash = %s AND pos = %s;",
+            (hash, pos),
+        )
         return {"result": len(result) > 0}
 
     def get_utxo(self, pubkeyhash: str) -> Dict[str, Any]:
         # Return the UTXO associated with a particular pubkeyhash
 
-        result = database.query(f"SELECT hash, pos, satoshis, height FROM utxo WHERE pubkeyhash = '{pubkeyhash}';")
+        result = database.query(
+            "SELECT hash, pos, satoshis, height FROM utxo WHERE pubkeyhash = %s;",
+            (pubkeyhash,),
+        )
 
         retval = [{
             "height": x[3],
@@ -70,7 +76,10 @@ class TxAnalyser:
 
     def get_balance(self, pubkeyhash: str, blockheight: int) -> Dict[str, Any]:
         # Return the UTXO balance with a particular pubkeyhash
-        result = database.query(f"SELECT satoshis, height FROM utxo WHERE pubkeyhash = '{pubkeyhash}';")
+        result = database.query(
+            "SELECT satoshis, height FROM utxo WHERE pubkeyhash = %s;",
+            (pubkeyhash,),
+        )
         confirmed_height = blockheight - self.complete
 
         confirmed = sum([x[0] for x in result if x[1] >= 0 and x[1] <= confirmed_height])
@@ -83,7 +92,9 @@ class TxAnalyser:
     def _read_block_offset(self, hash: str) -> Optional[int]:
         # Read block offset based on tx hash from database
         result = database.query(
-            f"SELECT blocks.`offset` FROM blocks INNER JOIN tx on tx.height = blocks.height where tx.hash='{hash}';")
+            "SELECT blocks.`offset` FROM blocks INNER JOIN tx on tx.height = blocks.height WHERE tx.hash = %s;",
+            (hash,),
+        )
         try:
             return result[0][0]
         except IndexError:
@@ -92,7 +103,9 @@ class TxAnalyser:
     def _read_tx_height_and_blockindex(self, hash: str) -> Optional[List[int]]:
         try:
             result = database.query(
-                f"SELECT height, blockindex FROM tx WHERE hash='{hash}';")
+                "SELECT height, blockindex FROM tx WHERE hash = %s;",
+                (hash,),
+            )
         except ProgrammingError as e:
             print(f"MySQL ProgrammingError {e}")
             return None
@@ -162,16 +175,16 @@ class TxAnalyser:
         # Return true if txid is in txs or mempool or collection
         # self.txs.contains_key(&hash) || self.mempool.contains_key(&hash)
         try:
-            txs = database.query(f"SELECT * FROM tx WHERE hash = '{hash}';")
+            txs = database.query("SELECT * FROM tx WHERE hash = %s;", (hash,))
         except ProgrammingError as e:
             print(f"MySQL ProgrammingError {e}")
         else:
             if len(txs) > 0:
                 return True
-        mempool = database.query(f"SELECT * FROM mempool WHERE hash = '{hash}';")
+        mempool = database.query("SELECT * FROM mempool WHERE hash = %s;", (hash,))
         if len(mempool) > 0:
             return True
-        collection = database.query(f"SELECT * FROM collection WHERE hash = '{hash}';")
+        collection = database.query("SELECT * FROM collection WHERE hash = %s;", (hash,))
         if len(collection) > 0:
             return True
         return False
@@ -179,7 +192,11 @@ class TxAnalyser:
     def get_tx_merkle_proof(self, hash: str) -> Dict[str, Any]:
         # Given the txid return the merkle branch proof for a confirmed transaction
         # Get the block
-        block = database.query(f"SELECT blocks.height, blocks.hash, merkle_root FROM blocks INNER JOIN tx on tx.height = blocks.height WHERE tx.hash='{hash}';")
+        block = database.query(
+            "SELECT blocks.height, blocks.hash, merkle_root FROM blocks "
+            "INNER JOIN tx on tx.height = blocks.height WHERE tx.hash = %s;",
+            (hash,),
+        )
         try:
             height = block[0][0]
             block_hash = block[0][1]
@@ -190,7 +207,10 @@ class TxAnalyser:
             }
         # Get the txs in the block
         try:
-            result = database.query(f"SELECT hash FROM tx WHERE height = '{height}' ORDER BY blockindex ASC;")
+            result = database.query(
+                "SELECT hash FROM tx WHERE height = %s ORDER BY blockindex ASC;",
+                (height,),
+            )
             txs = [x[0] for x in result]
         except ProgrammingError as e:
             print(f"MySQL ProgrammingError {e}")


### PR DESCRIPTION
## Summary
- Add optional `params` support to `database.query()` for bound MySQL parameters
- Replace f-string SQL in the REST API query layer with parameterized queries for user-supplied hashes, heights, pubkeyhashes, and collection names
- Update maintenance tools to use bound parameters; validate table names against an allowlist where identifiers cannot be parameterized

## Test plan
- [ ] Start the Python API and verify block, tx, utxo, balance, and collection endpoints still return expected results
- [ ] Confirm invalid or malformed input returns errors rather than executing injected SQL
- [ ] Run `./lint.sh` (flake8 + mypy) on `python/src`


Made with [Cursor](https://cursor.com)