### PR TITLE
Fail fast when Python config is missing or invalid

### DIFF
--- a/python/src/config.py
+++ b/python/src/config.py
@@ -1,22 +1,77 @@
-import toml
-import logging
+import sys
 from typing import Any, MutableMapping
 
-
-LOGGER = logging.getLogger(__name__)
+import toml
 
 
 ConfigType = MutableMapping[str, Any]
 
 
+class ConfigError(Exception):
+    """Raised when the configuration file is missing, invalid, or incomplete."""
+
+
+def _require_section(config: ConfigType, section: str, filename: str) -> ConfigType:
+    value = config.get(section)
+    if not isinstance(value, MutableMapping):
+        raise ConfigError(
+            f"Config '{filename}' is missing required section [{section}]."
+        )
+    return value
+
+
+def _require_key(section: ConfigType, section_name: str, key: str, filename: str) -> Any:
+    if key not in section:
+        raise ConfigError(
+            f"Config '{filename}' section [{section_name}] is missing required key '{key}'."
+        )
+    return section[key]
+
+
+def _validate_config(config: ConfigType, filename: str) -> None:
+    service = _require_section(config, "service", filename)
+    network = _require_key(service, "service", "network", filename)
+    if not isinstance(network, str) or not network:
+        raise ConfigError(
+            f"Config '{filename}' section [service] must set a non-empty 'network'."
+        )
+
+    _require_section(config, network, filename)
+    _require_section(config, "web_interface", filename)
+    _require_section(config, "utxo", filename)
+    _require_section(config, "dynamic_config", filename)
+
+    web_interface = config["web_interface"]
+    for key in ("address", "log_level", "reload", "rust_url"):
+        _require_key(web_interface, "web_interface", key, filename)
+
+
 def load_config(filename: str) -> ConfigType:
-    """ Load config from provided toml file
-    """
+    """Load and validate config from the provided TOML file."""
     try:
         with open(filename, "r") as f:
             config = toml.load(f)
-        return config
     except FileNotFoundError as e:
-        print(f"load_config - File not found error {e}")
-        LOGGER.warning(f"load_config - File not found error {e}")
-        return {}
+        raise ConfigError(
+            f"Unable to read config file '{filename}'. "
+            "Check the path and that the file exists."
+        ) from e
+    except toml.TomlDecodeError as e:
+        raise ConfigError(
+            f"Unable to parse config file '{filename}': {e}"
+        ) from e
+
+    if not isinstance(config, MutableMapping):
+        raise ConfigError(f"Config '{filename}' must contain a TOML table at the top level.")
+
+    _validate_config(config, filename)
+    return config
+
+
+def load_config_or_exit(filename: str) -> ConfigType:
+    """Load config, printing a clear error and exiting on failure."""
+    try:
+        return load_config(filename)
+    except ConfigError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 from p2p_framework.object import CTransaction
 
-from config import load_config, ConfigType
+from config import load_config, ConfigError, ConfigType
 from tx_analyser import tx_analyser
 from block_manager import block_manager
 from collection import collection, hexstr_to_tx, Monitor
@@ -37,7 +37,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-config: ConfigType = load_config("../data/uaasr.toml")
+try:
+    config: ConfigType = load_config("../data/uaasr.toml")
+except ConfigError as e:
+    raise RuntimeError(f"Failed to load UaaS config: {e}") from e
 web_address: str = config["web_interface"]["address"]
 rust_url: str = config["web_interface"]["rust_url"]
 

--- a/python/src/web.py
+++ b/python/src/web.py
@@ -6,7 +6,7 @@ from blockfile import blockfile
 from tx_analyser import tx_analyser
 from logic import logic
 
-from config import load_config, ConfigType
+from config import load_config_or_exit, ConfigType
 from collection import collection
 
 
@@ -31,7 +31,7 @@ def run_webserver(config: ConfigType):
 def main():
     """ main function - reads config, sets up system starts REST API
     """
-    config = load_config("../data/uaasr.toml")
+    config = load_config_or_exit("../data/uaasr.toml")
     database.set_config(config)
     blockfile.set_config(config)
     tx_analyser.set_config(config)


### PR DESCRIPTION
## Summary
- Replace silent `{}` return on missing config with a clear `ConfigError`
- Validate required sections (`service`, network block, `web_interface`, `utxo`, `dynamic_config`) at load time
- Use `load_config_or_exit()` in `web.py` for a clean stderr message on startup failure

## Test plan
- [ ] Run `./web.py` with a valid `data/uaasr.toml` — API starts normally
- [ ] Rename or remove the config file — startup exits with a clear error instead of `KeyError`
- [ ] Introduce a TOML syntax error — startup reports a parse error with file path


Made with [Cursor](https://cursor.com)