### PR TITLE
Add health endpoints

### DIFF
--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 from p2p_framework.object import CTransaction
 
+from database import database
 from config import load_config, ConfigError, ConfigType
 from tx_analyser import tx_analyser
 from block_manager import block_manager
@@ -51,6 +52,24 @@ def root() -> Dict[str, str]:
     return {
         "name": "UTXO as a Service (UaaS) REST API",
         "description": "UTXO as a Service REST API",
+    }
+
+
+@app.get("/health", tags=["Status"])
+def health(response: Response) -> Dict[str, Any]:
+    """Return service health, including database connectivity."""
+    try:
+        database.query("SELECT 1")
+    except Exception as e:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {
+            "status": "unhealthy",
+            "service": "uaas-web",
+            "database": str(e),
+        }
+    return {
+        "status": "ok",
+        "service": "uaas-web",
     }
 
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,7 +25,7 @@ mod uaas;
 use crate::{
     config::get_config,
     peer_event::{PeerEventMessage, PeerEventType},
-    rest_api::{add_monitor, broadcast_tx, delete_monitor, version, AppState},
+    rest_api::{add_monitor, broadcast_tx, delete_monitor, health, version, AppState},
     thread_manager::ThreadManager,
     thread_tracker::ThreadTracker,
     uaas::logic::Logic,
@@ -88,6 +88,7 @@ async fn main() {
     let server = HttpServer::new(move || {
         App::new()
             .app_data(web_state.clone())
+            .service(health)
             .service(broadcast_tx)
             .service(version)
             .service(add_monitor)

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -31,6 +31,22 @@ struct BroadcastTxResponse {
     detail: String,
 }
 
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    service: &'static str,
+    version: &'static str,
+}
+
+#[get("/health")]
+async fn health() -> impl Responder {
+    web::Json(HealthResponse {
+        status: "ok",
+        service: "uaas-service",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
 #[get("/version")]
 async fn version(_data: web::Data<AppState>) -> impl Responder {
     log::info!("version");


### PR DESCRIPTION
## Summary
- Add `GET /health` to the Rust internal API (liveness + version)
- Add `GET /health` to the Python REST API with a database connectivity check (returns 503 if DB unreachable)

## Test plan
- [ ] `curl http://localhost:8081/health` — Rust service returns `{"status":"ok",...}`
- [ ] `curl http://localhost:5010/health` — Python API returns ok when MariaDB is up
- [ ] Stop database and confirm Python `/health` returns 503


Made with [Cursor](https://cursor.com)