### PR TITLE
Fix CORS configuration in Python REST API

### DIFF
--- a/data/uaasr.toml
+++ b/data/uaasr.toml
@@ -162,6 +162,10 @@ reload = false
 rust_url = "http://host.docker.internal:8081"
 # rust_url = "http://127.0.0.1:8081"
 
+# CORS: credentials cannot be used with allow_origins = ["*"]
+cors_origins = ["*"]
+cors_allow_credentials = false
+
 
 [dynamic_config]
 filename = "../data/dynamic.toml"

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -28,21 +28,26 @@ app = FastAPI(
     openapi_tags=tags_metadata,
 )
 
-# Enable CORS
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 try:
     config: ConfigType = load_config("../data/uaasr.toml")
 except ConfigError as e:
     raise RuntimeError(f"Failed to load UaaS config: {e}") from e
-web_address: str = config["web_interface"]["address"]
-rust_url: str = config["web_interface"]["rust_url"]
+web_interface = config["web_interface"]
+web_address: str = web_interface["address"]
+rust_url: str = web_interface["rust_url"]
+
+cors_origins = web_interface.get("cors_origins", ["*"])
+cors_allow_credentials = web_interface.get("cors_allow_credentials", False)
+if cors_allow_credentials and "*" in cors_origins:
+    cors_allow_credentials = False
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=cors_allow_credentials,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/", tags=["Web"])


### PR DESCRIPTION
## Summary
- Remove invalid combination of `allow_origins=["*"]` with `allow_credentials=True`
- Add optional `cors_origins` and `cors_allow_credentials` settings under `[web_interface]`
- Default to open origins without credentials (valid for browser CORS)

## Test plan
- [ ] Start Python API and confirm Swagger at `/docs` loads in the browser
- [ ] `curl -H "Origin: http://example.com" -I http://localhost:5010/` returns `Access-Control-Allow-Origin: *`
- [ ] To use credentials in production, set explicit origins in config (not `*`)


Made with [Cursor](https://cursor.com)