### PR TITLE
Use MySQL connection pool in Python database layer

### DIFF
--- a/python/src/database.py
+++ b/python/src/database.py
@@ -1,41 +1,46 @@
 from typing import Any, List, Optional, Sequence
 
-from mysql.connector import connect
+from mysql.connector.pooling import MySQLConnectionPool
+
 from config import ConfigType
 
 
 class Database:
     def __init__(self):
-        self.host: str
-        self.user: str
-        self.password: str
-        self.database: str
+        self._pool: MySQLConnectionPool | None = None
 
     def set_config(self, config: ConfigType):
-        network = config['service']['network']
-        self.host = config[network]["host"]
-        self.user = config[network]["user"]
-        self.password = config[network]["password"]
-        self.database = config[network]["database"]
+        network = config["service"]["network"]
+        self._pool = MySQLConnectionPool(
+            pool_name="uaas_pool",
+            pool_size=5,
+            pool_reset_session=True,
+            host=config[network]["host"],
+            user=config[network]["user"],
+            password=config[network]["password"],
+            database=config[network]["database"],
+        )
 
     def query(
         self,
         query_string: str,
         params: Optional[Sequence[Any]] = None,
     ) -> List[Any]:
-        with connect(
-            host=self.host,
-            user=self.user,
-            password=self.password,
-            database=self.database,
-        ) as connection:
+        if self._pool is None:
+            raise RuntimeError("Database pool is not configured")
+
+        connection = self._pool.get_connection()
+        try:
             cursor = connection.cursor()
-            cursor.execute(query_string, params or ())
-            retval = list(cursor.fetchall())
-            connection.commit()
-            cursor.close()
+            try:
+                cursor.execute(query_string, params or ())
+                retval = list(cursor.fetchall())
+                connection.commit()
+                return retval
+            finally:
+                cursor.close()
+        finally:
             connection.close()
-            return retval
 
 
 database = Database()


### PR DESCRIPTION
## Summary
- Replace per-query `connect()` calls with a `MySQLConnectionPool` (size 5)
- Add optional query parameters to `database.query()` for compatibility with the SQL injection fix PR
- Use `fetchall()` for mypy-friendly result handling

## Test plan
- [ ] Start Python API with MariaDB running
- [ ] Hit several endpoints (`/status`, `/block/latest`, `/health` if merged) and confirm responses are unchanged
- [ ] Run `./lint.sh` with `requirements-dev.txt` installed


Made with [Cursor](https://cursor.com)