### PR TITLE
Add Docker Compose healthchecks

### DIFF
--- a/Rust_Dockerfile
+++ b/Rust_Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /app/rust
 RUN cargo install --path . --root /app
 
 FROM debian:bookworm-slim
-RUN apt-get update
-RUN apt-get install -y libssl3
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libssl3 curl \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/bin/uaas /app/bin/uaas
 COPY --from=builder /app/data /app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,12 @@ services:
     depends_on:
       database:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8081/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
     volumes:
       - ./data:/app/data
       - ./data/uaasr.docker.toml:/app/data/uaasr.toml:ro
@@ -70,7 +76,17 @@ services:
       database:
         condition: service_healthy
       uaas_backend:
-        condition: service_started
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:5010/health')\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     volumes:
       - ./python/src:/app/python
       - ./data:/app/data

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 from p2p_framework.object import CTransaction
 
+from database import database
 from config import load_config, ConfigError, ConfigType
 from tx_analyser import tx_analyser
 from block_manager import block_manager
@@ -51,6 +52,24 @@ def root() -> Dict[str, str]:
     return {
         "name": "UTXO as a Service (UaaS) REST API",
         "description": "UTXO as a Service REST API",
+    }
+
+
+@app.get("/health", tags=["Status"])
+def health(response: Response) -> Dict[str, Any]:
+    """Return service health, including database connectivity."""
+    try:
+        database.query("SELECT 1")
+    except Exception as e:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {
+            "status": "unhealthy",
+            "service": "uaas-web",
+            "database": str(e),
+        }
+    return {
+        "status": "ok",
+        "service": "uaas-web",
     }
 
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,7 +25,7 @@ mod uaas;
 use crate::{
     config::get_config,
     peer_event::{PeerEventMessage, PeerEventType},
-    rest_api::{add_monitor, broadcast_tx, delete_monitor, version, AppState},
+    rest_api::{add_monitor, broadcast_tx, delete_monitor, health, version, AppState},
     thread_manager::ThreadManager,
     thread_tracker::ThreadTracker,
     uaas::logic::Logic,
@@ -88,6 +88,7 @@ async fn main() {
     let server = HttpServer::new(move || {
         App::new()
             .app_data(web_state.clone())
+            .service(health)
             .service(broadcast_tx)
             .service(version)
             .service(add_monitor)

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -31,6 +31,22 @@ struct BroadcastTxResponse {
     detail: String,
 }
 
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    service: &'static str,
+    version: &'static str,
+}
+
+#[get("/health")]
+async fn health() -> impl Responder {
+    web::Json(HealthResponse {
+        status: "ok",
+        service: "uaas-service",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
 #[get("/version")]
 async fn version(_data: web::Data<AppState>) -> impl Responder {
     log::info!("version");


### PR DESCRIPTION
## Summary
- Add `/health` probes for `uaas_backend` (curl) and `uaas_web` (Python urllib)
- Wait for Rust backend health before starting the Python API (`service_healthy` instead of `service_started`)
- Install `curl` in the Rust runtime image for container healthchecks
- Includes health endpoints from #35 (cherry-picked) so this PR is self-contained with #29 compose fixes

## Test plan
- [ ] `./build.sh` to rebuild images with curl in the Rust container
- [ ] `docker compose up -d` — database, backend, and web all reach `healthy`
- [ ] `docker compose ps` shows healthy status for all three services
- [ ] Stop MariaDB and confirm `uaas_web` transitions to unhealthy (503 from `/health`)
- [ ] `curl http://localhost:8081/health` and `curl http://localhost:5010/health` return ok when stack is up

Depends on #29 for MariaDB, port 8081, and `uaasr.docker.toml`. Supersedes or can merge alongside #35 for health endpoints.


Made with [Cursor](https://cursor.com)