### PR TITLE
Replace unwrap and panic in Rust hot paths

### DIFF
--- a/rust/src/event_handler.rs
+++ b/rust/src/event_handler.rs
@@ -53,8 +53,10 @@ impl EventHandler {
     }
 
     fn send_msg(&self, msg: PeerEventMessage) {
-        let tx = self.mutex_tx.lock().unwrap();
-        tx.send(msg).unwrap()
+        let tx = self.mutex_tx.lock().unwrap_or_else(|e| e.into_inner());
+        if tx.send(msg).is_err() {
+            log::warn!("Failed to send peer event; event loop unavailable");
+        }
     }
 
     // Message handlers
@@ -114,7 +116,9 @@ impl EventHandler {
         let p = FeeFilter { minfee: 0 };
         let m = Message::FeeFilter(p);
         if self.get_connected() {
-            peer.send(&m).unwrap();
+            if let Err(e) = peer.send(&m) {
+                log::warn!("Failed to send feefilter response to peer: {:?}", e);
+            }
         }
     }
 
@@ -126,7 +130,9 @@ impl EventHandler {
         };
         let m = Message::SendCmpct(p);
         if self.get_connected() {
-            peer.send(&m).unwrap();
+            if let Err(e) = peer.send(&m) {
+                log::warn!("Failed to send sendcmpct response to peer: {:?}", e);
+            }
         }
     }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -118,7 +118,9 @@ async fn main() {
     server.await.unwrap();
 
     // Wait for peer threads
-    handle.join().unwrap();
+    if let Err(e) = handle.join() {
+        log::error!("Peer manager thread panicked during shutdown: {:?}", e);
+    }
 }
 
 async fn wait_for_shutdown_signal() {

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -72,9 +72,18 @@ async fn broadcast_tx(hexstr: String, data: web::Data<AppState>) -> Result<impl 
     let hash = tx.hash().encode();
 
     // Send Tx for broadcast
-    data.msg_from_rest_api
+    if data
+        .msg_from_rest_api
         .send(RestEventMessage::TxForBroadcast(tx))
-        .unwrap();
+        .is_err()
+    {
+        log::error!("REST API channel closed; cannot broadcast transaction");
+        let response = BroadcastTxResponse {
+            status: "Failed".to_string(),
+            detail: "Service unavailable".to_string(),
+        };
+        return Ok(web::Json(response));
+    }
 
     // Return hash as hex_str, if successful
     let response = BroadcastTxResponse {
@@ -94,11 +103,16 @@ async fn add_monitor(
 
     let cc = monitor.into_inner();
 
-    data.msg_from_rest_api
+    if data
+        .msg_from_rest_api
         .send(RestEventMessage::AddMonitor(cc))
-        .unwrap();
+        .is_err()
+    {
+        log::error!("REST API channel closed; cannot add monitor");
+        return Ok(HttpResponse::ServiceUnavailable().body("Service unavailable"));
+    }
 
-    Ok(HttpResponse::Ok())
+    Ok(HttpResponse::Ok().finish())
 }
 
 #[delete("/collection/monitor/{monitor_name}")]
@@ -108,9 +122,14 @@ async fn delete_monitor(
 ) -> Result<impl Responder> {
     log::info!("delete_monitor '{}'", &monitor_name);
 
-    data.msg_from_rest_api
+    if data
+        .msg_from_rest_api
         .send(RestEventMessage::DeleteMonitor(monitor_name.to_string()))
-        .unwrap();
+        .is_err()
+    {
+        log::error!("REST API channel closed; cannot delete monitor");
+        return Ok(HttpResponse::ServiceUnavailable().body("Service unavailable"));
+    }
 
-    Ok(HttpResponse::Ok())
+    Ok(HttpResponse::Ok().finish())
 }

--- a/rust/src/thread_manager.rs
+++ b/rust/src/thread_manager.rs
@@ -148,9 +148,12 @@ impl ThreadManager {
                         }
                         if let Some(peer) = thread_tracker.get_connected_peer() {
                             let message = Message::Tx(tx.clone());
-                            peer.send(&message).unwrap();
-                            logic.on_tx(tx, true);
-                            logic.flush_database_cache();
+                            if let Err(e) = peer.send(&message) {
+                                log::warn!("Failed to broadcast transaction to peer: {:?}", e);
+                            } else {
+                                logic.on_tx(tx, true);
+                                logic.flush_database_cache();
+                            }
                         }
                     }
                     RestEventMessage::AddMonitor(monitor) => logic.tx_analyser.add_monitor(monitor),

--- a/rust/src/thread_tracker.rs
+++ b/rust/src/thread_tracker.rs
@@ -87,8 +87,9 @@ impl ThreadTracker {
             let started_at = peer.started_at;
 
             if let Some(thread) = peer.thread {
-                // wait for it
-                thread.join().unwrap();
+                if let Err(e) = thread.join() {
+                    log::error!("Peer thread join failed for {}: {:?}", ip, e);
+                }
 
                 // Create a new entry to replace the existing one
                 let new_peer = PeerThread {

--- a/rust/src/uaas/logic.rs
+++ b/rust/src/uaas/logic.rs
@@ -260,7 +260,17 @@ impl Logic {
 
             // Build getblocks message - this results in an inv message
             let mut locator = BlockLocator::default();
-            let hash = Hash256::decode(&hash).unwrap();
+            let hash = match Hash256::decode(&hash) {
+                Ok(hash) => hash,
+                Err(e) => {
+                    log::error!(
+                        "Invalid block hash for GetBlocks request: {} ({:?})",
+                        hash,
+                        e
+                    );
+                    return;
+                }
+            };
             locator.block_locator_hashes.push(hash);
             let message = Message::GetBlocks(locator);
             self.send_message_queue.push(message)
@@ -273,14 +283,10 @@ impl Logic {
             let want = Message::GetData(Inv { objects: object });
             self.send_message_queue.push(want);
         } else {
-            // really shouldn't get here
-            log::info!("wrong place");
-            self.block_inventory
-                .iter()
-                .enumerate()
-                .for_each(|(i, list)| log::info!("list {}, len = {}", i, list.len()));
-            panic!("should not get here");
-            // block_inv not empty but nothing in first entry
+            log::error!("Block inventory has empty first entry; removing stale entry");
+            if !self.block_inventory.is_empty() {
+                self.block_inventory.remove(0);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- **REST API:** return 503 / failed response when the event channel is closed instead of panicking
- **Event handler:** log peer send and channel failures; recover from poisoned mutex on the event sender
- **Thread manager:** log broadcast send failures; only persist tx after successful peer send
- **Logic:** replace `panic!` on empty block inventory with recovery; log invalid hashes instead of unwrap
- **Shutdown:** log peer thread join failures instead of panicking

## Test plan
- [ ] `cd rust && cargo clippy -- -D warnings`
- [ ] `cargo run` — connect to a peer, press Ctrl+C; confirm clean shutdown logs
- [ ] `curl -X POST http://localhost:8081/tx/raw -d '...'` — broadcast still works when peer connected
- [ ] Stop service and hit REST endpoints — no panic, 503 returned


Made with [Cursor](https://cursor.com)