### PR TITLE
Document legacy Python p2p_framework

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -44,6 +44,12 @@ To lint the source code:
 ```
 This requires `flake8` and `mypy` from `requirements-dev.txt`.
 
+## Python `p2p_framework`
+
+The Python REST API uses a vendored package at `python/src/p2p_framework/` for Bitcoin transaction/block (de)serialization and hashing. **P2P sync runs in Rust**, not in this package.
+
+Most files under `p2p_framework/` are legacy mininode-style networking code and are **not** imported by the running web service. See [`python/src/p2p_framework/README.md`](../python/src/p2p_framework/README.md) for which modules are active vs legacy.
+
 # Background Links
 Details of the messages and the Bitcoin SV peer to peer protocol can be found in the following links:
 

--- a/python/src/p2p_framework/README.md
+++ b/python/src/p2p_framework/README.md
@@ -1,0 +1,34 @@
+# Python P2P framework
+
+Vendored Bitcoin-style serialization and (legacy) P2P networking code used by the Python REST API layer.
+
+P2P sync and block download are handled by the **Rust service** (`rust/`). This package is **not** on the hot path for production sync — the Python API uses only the data-structure and hashing modules.
+
+## Active modules (used by the REST API)
+
+| Module | Purpose | Imported by |
+|--------|---------|-------------|
+| `object.py` | `CTransaction`, `CBlock`, `CBlockHeader`, and related types | `rest_api`, `tx_analyser`, `collection`, `blockfile`, `block_manager`, tools |
+| `hash.py` | `hash256`, `sha256`, `siphash256` | `merkle`, `util`, tools |
+| `serial.py` | Binary (de)serialization helpers | Used internally by `object.py` |
+| `util.py` | Hex/byte conversion utilities | Used internally by `object.py` and `serial.py` |
+| `consensus.py` | Protocol constants | Used internally by `object.py` and `message.py` |
+| `streams.py` | Stream type helpers for message parsing | Used internally by `message.py` |
+
+## Legacy modules (not used by the running service)
+
+These implement a Python **mininode**-style P2P client (asyncore-based). Nothing in `web.py`, `rest_api.py`, or the main query path imports them. They remain for reference and may be removed in a future cleanup once serialization is extracted.
+
+| Module | Notes |
+|--------|-------|
+| `node_connection.py` | Low-level peer socket handling |
+| `node_callbacks.py` | Default P2P message callbacks |
+| `network_thread.py` | Background asyncore network thread |
+| `message.py` | P2P message constructors |
+| `merkle.py` | Merkle tree helpers (superseded by `../merkle.py` for API use) |
+
+## Maintenance guidance
+
+- Prefer extending the **Rust** service for new P2P or sync behaviour.
+- When changing transaction or block parsing in Python, update `object.py` / `hash.py` and run `./lint.sh`.
+- Do not add new production dependencies on the legacy networking modules listed above.


### PR DESCRIPTION
## Summary
- Add `python/src/p2p_framework/README.md` describing active modules (`object`, `hash`, serialization helpers) vs legacy P2P networking code
- Note in `docs/Development.md` that P2P sync is handled by Rust and link to the README

No code removed — the legacy modules are documented as unused by the running service so future work can safely extract or delete them.

## Test plan
- [ ] Review README module list against imports in `python/src/`
- [ ] Confirm Development.md link resolves in GitHub preview


Made with [Cursor](https://cursor.com)