### PR TITLE
Update Python and Rust dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-flake8==7.2.0
-mypy==1.15.0
+flake8==7.3.0
+mypy==2.1.0
 docker==7.1.0
 types-toml==0.10.8.20260518
 types-requests==2.33.0.20260518

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 toml==0.10.2
-fastapi==0.115.12
+fastapi==0.136.3
 fastapi-utils==0.8.0
-uvicorn[standard]==0.34.2
-mysql-connector-python==9.3.0
-requests==2.32.3
+uvicorn[standard]==0.48.0
+mysql-connector-python==9.7.0
+requests==2.34.2

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "btoi"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+checksum = "3b5ab9db53bcda568284df0fd39f6eac24ad6f7ba7ff1168b9e76eba6576b976"
 dependencies = [
  "num-traits",
 ]
@@ -1253,9 +1253,9 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "memchr"
@@ -1299,9 +1299,9 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mysql"
-version = "26.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2510a735f601bab18202b07ea0a197bd1d130d3a5ce2edf4577d225f0c3ee4"
+checksum = "4a732193888328fc060ab901c0ed1355521267a51ffbfd9a0b3786434c6b8e7f"
 dependencies = [
  "bufstream",
  "bytes",
@@ -1315,7 +1315,7 @@ dependencies = [
  "named_pipe",
  "pem",
  "percent-encoding",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "twox-hash",
  "url",
 ]
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.35.5"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
+checksum = "4b42ced54aa8ac97226486337973f9bc3956e24f03a23e88a6e18f640959d6e2"
 dependencies = [
  "base64",
  "bitflags",
@@ -1894,16 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,7 +2104,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2251,8 +2253,8 @@ dependencies = [
  "retry",
  "serde",
  "serde_json",
- "signal-hook",
  "simple_logger",
+ "tokio",
  "toml",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,21 +8,21 @@ edition = "2021"
 [dependencies]
 chain-gang = { git = "https://github.com/nchain-innovation/chain-gang.git" }
 
-serde = { version = "1.0.197", features =["derive"] }
-toml = "0.9.5"
-lazy_static = "1.4.0"
-serde_json = "1.0.114"
-mysql = "26.0.1"
-chrono = "0.4.35"
-rand = "0.9.2"
+serde = { version = "1.0.228", features =["derive"] }
+toml = "0.9.12"
+lazy_static = "1.5.0"
+serde_json = "1.0.150"
+mysql = "28.0.0"
+chrono = "0.4.44"
+rand = "0.9.4"
 hex = "0.4.3"
-regex = "1.10.3"
-retry = "2.0.0"
-actix-web = "4.8.0"
-tokio = { version = "1", features = ["signal", "macros"] }
-log = { version = "0.4.21", features = ["max_level_trace", "release_max_level_warn"] }
-simple_logger = "5.0.0"
-anyhow = "1.0.90"
+regex = "1.12.3"
+retry = "2.2.0"
+actix-web = "4.13.0"
+tokio = { version = "1.52", features = ["signal", "macros"] }
+log = { version = "0.4.30", features = ["max_level_trace", "release_max_level_warn"] }
+simple_logger = "5.2.0"
+anyhow = "1.0.102"
 
 [features]
 # Introduce random orphans into the download stream


### PR DESCRIPTION
## Summary
- **Python:** fastapi 0.136.3, uvicorn 0.48.0, mysql-connector-python 9.7.0, requests 2.34.2, flake8 7.3.0, mypy 2.1.0
- **Rust:** serde, actix-web 4.13, mysql 28.0.0, tokio 1.52, chrono, regex, log, and other crates updated via `cargo upgrade` + `cargo update`
- **chain-gang** git dependency refreshed in `Cargo.lock`

Left unchanged (already latest or no newer compatible release):
- `toml` 0.10.2 (PyPI), `fastapi-utils` 0.8.0, `docker` 7.1.0, `hex` 0.4.3 (Rust)
- `rand` kept at 0.9.x (0.10 requires code changes)
- `toml` kept at 0.9.x on Rust (1.x is incompatible)

## Test plan
- [ ] `pip install -r requirements-dev.txt && ./lint.sh`
- [ ] `cd rust && cargo clippy -- -D warnings && cargo test` (DB integration test needs MariaDB)
- [ ] CI Rust, Python, Docker jobs pass
- [ ] `./build.sh && docker compose up -d` smoke test


Made with [Cursor](https://cursor.com)