### PR TITLE
Skip Rust DB integration test without MariaDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: cargo test
         working-directory: rust
+        env:
+          UAAS_TEST_MYSQL_URL: mysql://maas:maas-password@127.0.0.1:3306/main_uaas_db
         run: cargo test
 
   python:

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -45,7 +45,6 @@ async fn version(_data: web::Data<AppState>) -> impl Responder {
 // curl -X POST -d 'txt=txt' 127.0.0.1:8080/echo
 #[post("/tx/raw")]
 async fn broadcast_tx(hexstr: String, data: web::Data<AppState>) -> Result<impl Responder> {
-    dbg!(&hexstr);
     // decode the hexstr to tx
     let bytes = match decode_hexstr(&hexstr) {
         Ok(b) => b,

--- a/rust/src/uaas/database.rs
+++ b/rust/src/uaas/database.rs
@@ -308,8 +308,17 @@ mod test {
 
     #[test]
     fn test_operation() {
-        let pool = Pool::new("mysql://maas:maas-password@localhost:3306/main_uaas_db")
-            .expect("Problem connecting to database. Check database is connected and database connection configuration is correct.\n");
+        let Some(url) = std::env::var("UAAS_TEST_MYSQL_URL").ok() else {
+            eprintln!("skipping database integration test: UAAS_TEST_MYSQL_URL not set");
+            return;
+        };
+
+        let pool = Pool::new(url.as_str()).unwrap_or_else(|err| {
+            panic!(
+                "Problem connecting to database at {url}. \
+                 Check database is connected and database connection configuration is correct.\n: {err}"
+            );
+        });
         let conn = pool.get_conn().unwrap();
         let (_tx, rx) = mpsc::channel();
         let mut database = Database {


### PR DESCRIPTION
## Summary
- Run `uaas::database::test::test_operation` only when `UAAS_TEST_MYSQL_URL` is set
- Set that env var in the CI Rust job so the integration test still runs against the MariaDB service container
- Remove leftover `dbg!` from the Rust broadcast tx handler

Fixes local `cargo test` failing when MariaDB is not running on port 3306 (common on dev machines using compose on 3307).

## Test plan
- [ ] `cd rust && cargo test` — all tests pass without MariaDB (DB test skipped)
- [ ] `UAAS_TEST_MYSQL_URL=mysql://maas:maas-password@127.0.0.1:3307/main_uaas_db cargo test` — DB test runs when compose DB is up
- [ ] CI Rust job passes with env var set


Made with [Cursor](https://cursor.com)