### PR TITLE
Add HTTP timeouts for Rust backend proxy calls

### DIFF
--- a/python/src/logic.py
+++ b/python/src/logic.py
@@ -6,6 +6,8 @@ from block_manager import block_manager
 from config import ConfigType
 from mysql.connector.errors import ProgrammingError
 
+RUST_REQUEST_TIMEOUT = 30  # seconds
+
 
 class Logic:
     def __init__(self):
@@ -28,7 +30,9 @@ class Logic:
     def _get_version(self) -> str:
         url = self.rust_url + "/version"
         try:
-            result = requests.get(url)
+            result = requests.get(url, timeout=RUST_REQUEST_TIMEOUT)
+        except requests.exceptions.Timeout:
+            print(f"timeout requesting version from {url}")
         except requests.exceptions.ConnectionError as e:
             print(f"failure = {str(e)}, url = {url}")
         else:

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -14,6 +14,8 @@ from collection import collection, hexstr_to_tx, Monitor
 from logic import logic
 from util import address_to_public_key_hash
 
+RUST_REQUEST_TIMEOUT = 30  # seconds
+
 tags_metadata = [
     {
         "name": "UTXO as a Service (UaaS) REST API",
@@ -137,7 +139,12 @@ def broadcast_tx_hex(tx: Tx, response: Response) -> Dict[str, Any]:
         response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
         return {"failure": f" Transaction {hash} already exists."}
     try:
-        result = requests.post(rust_url + "/tx/raw", data=tx.tx)
+        result = requests.post(
+            rust_url + "/tx/raw", data=tx.tx, timeout=RUST_REQUEST_TIMEOUT
+        )
+    except requests.exceptions.Timeout:
+        response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
+        return {"failure": "Rust service request timed out"}
     except requests.exceptions.ConnectionError as e:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
         print(f"failure = {str(e)}")
@@ -254,7 +261,12 @@ def add_monitor(monitor: Monitor, response: Response) -> Dict[str, Any]:
     data = monitor.model_dump(mode='json')
     print("data=", data)
     try:
-        result = requests.post(rust_url + "/collection/monitor", json=data)
+        result = requests.post(
+            rust_url + "/collection/monitor", json=data, timeout=RUST_REQUEST_TIMEOUT
+        )
+    except requests.exceptions.Timeout:
+        response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
+        return {"failure": "Rust service request timed out"}
     except requests.exceptions.ConnectionError as e:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
         print(f"failure = {str(e)}")
@@ -292,7 +304,13 @@ def delete_monitor(monitor_name: str, response: Response) -> Dict[str, Any]:
 
     # call uaas backend
     try:
-        result = requests.delete(rust_url + f"/collection/monitor/{monitor_name}")
+        result = requests.delete(
+            rust_url + f"/collection/monitor/{monitor_name}",
+            timeout=RUST_REQUEST_TIMEOUT,
+        )
+    except requests.exceptions.Timeout:
+        response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
+        return {"failure": "Rust service request timed out"}
     except requests.exceptions.ConnectionError as e:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
         print(f"failure = {str(e)}")


### PR DESCRIPTION
## Summary
- Add 30-second timeouts to all `requests` calls from the Python API to the Rust service (tx broadcast, monitor add/delete, version in `/status`)
- Return **504 Gateway Timeout** when the Rust backend does not respond in time

Prevents the Python API from hanging indefinitely when `uaas_backend` is down or overloaded.

## Test plan
- [ ] `./lint.sh`
- [ ] With Rust service stopped, `POST /tx/hex` returns 503 quickly (connection error), not a hang
- [ ] With Rust service running, broadcast and monitor endpoints still work normally


Made with [Cursor](https://cursor.com)