### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /rust
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to open weekly update PRs for:
  - **Cargo** (`rust/Cargo.toml`)
  - **pip** (`requirements.txt`, `requirements-dev.txt`)
  - **Docker** (`Rust_Dockerfile`, `Python_Dockerfile`, compose base images)
  - **GitHub Actions** (`.github/workflows/ci.yml`)

## Test plan
- [ ] Merge and confirm Dependabot opens its first scan within 24h (Settings → Code security → Dependabot)
- [ ] Review any auto-opened update PRs before merging

Note: the `chain-gang` git dependency is not managed by Dependabot.


Made with [Cursor](https://cursor.com)