### PR TITLE
Fix collection address decoding for mainnet

### DIFF
--- a/rust/src/uaas/collection.rs
+++ b/rust/src/uaas/collection.rs
@@ -18,9 +18,13 @@ use regex::Regex;
 use retry::{delay, retry};
 
 /// Given an address return a locking script in hexstr format
-fn address_to_lock_script(address: &str) -> Result<String> {
-    let (hash160, address_type) = addr_decode(address, Network::BSV_Testnet)?;
-    assert!(address_type == AddressType::P2PKH);
+fn address_to_lock_script(address: &str, network: Network) -> Result<String> {
+    let (hash160, address_type) = addr_decode(address, network)?;
+    if address_type != AddressType::P2PKH {
+        return Err(anyhow!(
+            "Unsupported address type for collection monitor: only P2PKH addresses are supported"
+        ));
+    }
     let script = p2pkh::create_lock_script(&hash160);
     Ok(hex::encode(script.0))
 }
@@ -106,10 +110,10 @@ pub struct WorkingCollection {
 }
 
 impl WorkingCollection {
-    pub fn new(collection: CollectionConfig) -> Result<Self> {
+    pub fn new(collection: CollectionConfig, network: Network) -> Result<Self> {
         if let Some(ref addr) = collection.address {
             // address -> regex locking script
-            let pattern = address_to_lock_script(addr)?;
+            let pattern = address_to_lock_script(addr, network)?;
             let locking_script_regex = Regex::new(&pattern)?;
             return Ok(WorkingCollection {
                 collection: collection.clone(),

--- a/rust/src/uaas/tx_analyser.rs
+++ b/rust/src/uaas/tx_analyser.rs
@@ -4,6 +4,7 @@ use mysql::{prelude::*, Pool, PooledConn};
 
 use chain_gang::{
     messages::{Block, Tx, TxOut},
+    network::Network,
     script::Script,
     util::Hash256,
 };
@@ -49,6 +50,7 @@ pub struct TxAnalyser {
     collection: Vec<WorkingCollection>,
     collection_db: CollectionDatabase,
     dynamic_config: DynamicConfig,
+    network: Network,
 }
 
 impl TxAnalyser {
@@ -60,19 +62,22 @@ impl TxAnalyser {
         let collection_conn = pool.get_conn().unwrap();
 
         let save_txs = config.get_network_settings().save_txs;
+        let network = config
+            .get_network()
+            .expect("invalid network in config; expected mainnet, testnet, or stn");
         let dynamic_config = DynamicConfig::new(config);
         let mut collection: Vec<WorkingCollection> = Vec::new();
 
         // Load the collections
         for c in &config.collection {
-            match WorkingCollection::new(c.clone()) {
+            match WorkingCollection::new(c.clone(), network) {
                 Ok(wc) => collection.push(wc),
                 Err(e) => println!("Error parsing collection {:?}", e),
             }
         }
         // load the dynamic collection
         for c in &dynamic_config.collection {
-            match WorkingCollection::new(c.clone()) {
+            match WorkingCollection::new(c.clone(), network) {
                 Ok(wc) => collection.push(wc),
                 Err(e) => println!("Error parsing collection {:?}", e),
             }
@@ -90,6 +95,7 @@ impl TxAnalyser {
             collection,
             collection_db: CollectionDatabase::new(collection_conn, config),
             dynamic_config: dynamic_config.clone(),
+            network,
         }
     }
 
@@ -317,7 +323,7 @@ impl TxAnalyser {
         // Check name is not in collection
         if !self.is_name_in_collection(&monitor.name) {
             // add to collection
-            match WorkingCollection::new(monitor.clone()) {
+            match WorkingCollection::new(monitor.clone(), self.network) {
                 Ok(wc) => {
                     self.collection.push(wc);
                     // add to dynamic config


### PR DESCRIPTION
## Summary
- Decode collection monitor addresses using the network from config (`mainnet` / `testnet` / `stn`) instead of hardcoded `Network::BSV_Testnet`
- Return a clear error for non-P2PKH address types instead of panicking via `assert!`
- Pass the configured network through `TxAnalyser` when loading static, dynamic, and REST-added monitors

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test`
- [ ] On mainnet config, add an address monitor via REST and confirm txs matching that address are collected
- [ ] On testnet config, confirm existing address monitors still work


Made with [Cursor](https://cursor.com)