### PR TITLE
Add optional API key auth and security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ This is read when the service starts up.
 
 For more details about the configuration file see [here](docs/Configuration.md).
 
+## Security
+
+The REST APIs have no authentication by default and can broadcast transactions or modify collection monitors. For local development, bind to `127.0.0.1` and keep ports off the public internet. For shared or production use, set `api_key` in `[web_interface]` and read [docs/Security.md](docs/Security.md).
+
 
 ## Directories
 The following directories exist in this project:

--- a/data/uaasr.docker.toml
+++ b/data/uaasr.docker.toml
@@ -127,6 +127,9 @@ log_level = 'info'
 reload = false
 rust_url = "http://uaas_backend:8081"
 
+# Optional: require X-API-Key header on API requests (see docs/Security.md)
+# api_key = "change-me-to-a-long-random-secret"
+
 
 [dynamic_config]
 filename = "../data/dynamic.toml"

--- a/data/uaasr.toml
+++ b/data/uaasr.toml
@@ -166,6 +166,9 @@ rust_url = "http://host.docker.internal:8081"
 cors_origins = ["*"]
 cors_allow_credentials = false
 
+# Optional: require X-API-Key header on API requests (see docs/Security.md)
+# api_key = "change-me-to-a-long-random-secret"
+
 
 [dynamic_config]
 filename = "../data/dynamic.toml"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -144,4 +144,8 @@ The web interface section has the following fields:
 * `address` - this is the address and port that REST API will be provided on
 * `log_level` - this is the level that the REST API logs events at
 * `reload` - if set to true the webserver will reload if the source code is changed
+* `rust_url` - base URL of the Rust backend used for broadcast and collection monitor operations
+* `api_key` - *(optional)* when set, clients must send this value in the `X-API-Key` request header on all endpoints except `/health`. The same key is enforced on the Rust backend for mutating operations. Leave unset for local development with no authentication.
+
+For production deployments, bind the Python API to a private interface (for example `127.0.0.1:5010`) or place the service behind a reverse proxy. Do not expose the Rust API port (`8081`) or the database/admin ports to the public internet without additional network controls. See [Security](Security.md) for details.
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,0 +1,57 @@
+# Security
+
+UaaS exposes HTTP APIs and a database that were designed for trusted network environments. Before deploying beyond local development, review the following.
+
+## Network exposure
+
+| Service | Default port | Notes |
+|---------|--------------|-------|
+| Python REST API | 5010 | Query UTXO data, broadcast transactions, manage monitors |
+| Rust REST API | 8081 | Used internally by Python; also accepts broadcast and monitor changes |
+| MariaDB | 3307 (compose) | Stores blocks, UTXO set, collections |
+| Adminer (compose) | 8080 | Database admin UI with no built-in authentication |
+
+**Recommendations:**
+
+- Bind the Python API to `127.0.0.1` when running on a single host unless another layer (VPN, reverse proxy, firewall) restricts access.
+- Do not publish ports `8081`, `3307`, or `8080` to the public internet.
+- Replace default database passwords in `docker-compose.yml` and `data/uaasr.toml` for any shared or production environment.
+
+## Optional API key
+
+Set `api_key` under `[web_interface]` in `data/uaasr.toml` to require the `X-API-Key` header on API requests.
+
+```toml
+[web_interface]
+address = '127.0.0.1:5010'
+api_key = "change-me-to-a-long-random-secret"
+```
+
+When enabled:
+
+- All Python REST endpoints except `GET /health` require the header (Docker healthchecks continue to work).
+- Rust mutating endpoints (`POST /tx/raw`, collection monitor add/delete) require the same header.
+- Python forwards the key automatically when calling the Rust backend.
+
+Example request:
+
+```bash
+curl -H "X-API-Key: change-me-to-a-long-random-secret" \
+  http://127.0.0.1:5010/status
+```
+
+When `api_key` is omitted from config, authentication is disabled (default for local development).
+
+## Sensitive operations
+
+Even with an API key, treat the service as privileged infrastructure:
+
+- **Broadcast** (`POST /tx/hex`) relays transactions to the BSV network.
+- **Collection monitors** can capture and store arbitrary matching transactions.
+- **UTXO queries** reveal balance and transaction data for queried addresses.
+
+Use TLS termination at a reverse proxy when traffic crosses untrusted networks. This project does not terminate HTTPS itself.
+
+## Docker Compose
+
+The sample `docker-compose.yml` uses weak default credentials and exposes Adminer for convenience. Treat it as a development stack, not a production deployment template.

--- a/python/src/config.py
+++ b/python/src/config.py
@@ -45,6 +45,12 @@ def _validate_config(config: ConfigType, filename: str) -> None:
     for key in ("address", "log_level", "reload", "rust_url"):
         _require_key(web_interface, "web_interface", key, filename)
 
+    api_key = web_interface.get("api_key")
+    if api_key is not None and (not isinstance(api_key, str) or not api_key.strip()):
+        raise ConfigError(
+            f"Config '{filename}' section [web_interface] 'api_key' must be a non-empty string when set."
+        )
+
 
 def load_config(filename: str) -> ConfigType:
     """Load and validate config from the provided TOML file."""

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -4,6 +4,9 @@ from pydantic import BaseModel, field_validator
 from typing import Any, Dict
 import requests
 from io import BytesIO
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from p2p_framework.object import CTransaction
 
@@ -23,6 +26,7 @@ from validation import (
 )
 
 RUST_REQUEST_TIMEOUT = 30  # seconds
+API_KEY_HEADER = "X-API-Key"
 
 tags_metadata = [
     {
@@ -51,6 +55,22 @@ cors_allow_credentials = web_interface.get("cors_allow_credentials", False)
 if cors_allow_credentials and "*" in cors_origins:
     cors_allow_credentials = False
 
+api_key: str | None = web_interface.get("api_key")
+
+
+class ApiKeyMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if api_key and request.method != "OPTIONS" and request.url.path != "/health":
+            provided = request.headers.get(API_KEY_HEADER)
+            if provided != api_key:
+                return JSONResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content={"failure": "Unauthorized"},
+                )
+        return await call_next(request)
+
+
+app.add_middleware(ApiKeyMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,
@@ -58,6 +78,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def _rust_headers() -> Dict[str, str]:
+    if api_key:
+        return {API_KEY_HEADER: api_key}
+    return {}
 
 
 def _invalid_input(response: Response, message: str) -> Dict[str, str]:
@@ -201,7 +227,8 @@ def broadcast_tx_hex(tx: Tx, response: Response) -> Dict[str, Any]:
         return {"failure": f" Transaction {hash} already exists."}
     try:
         result = requests.post(
-            rust_url + "/tx/raw", data=tx.tx, timeout=RUST_REQUEST_TIMEOUT
+            rust_url + "/tx/raw", data=tx.tx, timeout=RUST_REQUEST_TIMEOUT,
+            headers=_rust_headers(),
         )
     except requests.exceptions.Timeout:
         response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
@@ -331,7 +358,8 @@ def add_monitor(monitor: Monitor, response: Response) -> Dict[str, Any]:
     print("data=", data)
     try:
         result = requests.post(
-            rust_url + "/collection/monitor", json=data, timeout=RUST_REQUEST_TIMEOUT
+            rust_url + "/collection/monitor", json=data, timeout=RUST_REQUEST_TIMEOUT,
+            headers=_rust_headers(),
         )
     except requests.exceptions.Timeout:
         response.status_code = status.HTTP_504_GATEWAY_TIMEOUT
@@ -381,6 +409,7 @@ def delete_monitor(monitor_name: str, response: Response) -> Dict[str, Any]:
         result = requests.delete(
             rust_url + f"/collection/monitor/{monitor_name}",
             timeout=RUST_REQUEST_TIMEOUT,
+            headers=_rust_headers(),
         )
     except requests.exceptions.Timeout:
         response.status_code = status.HTTP_504_GATEWAY_TIMEOUT

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -54,6 +54,12 @@ pub struct DynamicConfigConfig {
     pub filename: String,
 }
 
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct WebInterfaceConfig {
+    #[serde(default)]
+    pub api_key: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub service: Service,
@@ -63,6 +69,9 @@ pub struct Config {
     pub orphan: OrphanConfig,
     pub logging: LoggingConfig,
     pub dynamic_config: DynamicConfigConfig,
+
+    #[serde(default)]
+    pub web_interface: WebInterfaceConfig,
 
     pub collection: Vec<CollectionConfig>,
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -56,6 +56,7 @@ async fn main() {
 
     let app_state = AppState {
         msg_from_rest_api: tx_rest,
+        api_key: config.web_interface.api_key.clone(),
     };
     let web_state = web::Data::new(app_state);
 

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 use std::sync::mpsc;
 
 use actix_web::{
-    delete, get, http::header::ContentType, post, web, HttpResponse, Responder, Result,
+    delete, get, http::header::ContentType, post, web, HttpRequest, HttpResponse, Responder, Result,
 };
 use serde::Serialize;
 
@@ -23,6 +23,25 @@ pub enum RestEventMessage {
 // web interface state
 pub struct AppState {
     pub msg_from_rest_api: mpsc::Sender<RestEventMessage>,
+    pub api_key: Option<String>,
+}
+
+const API_KEY_HEADER: &str = "X-API-Key";
+
+fn authorize(req: &HttpRequest, api_key: &Option<String>) -> Option<HttpResponse> {
+    let expected = api_key.as_ref()?;
+    let authorized = req
+        .headers()
+        .get(API_KEY_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|provided| provided == expected);
+    if authorized {
+        None
+    } else {
+        Some(HttpResponse::Unauthorized().json(serde_json::json!({
+            "failure": "Unauthorized",
+        })))
+    }
 }
 
 #[derive(Serialize)]
@@ -60,27 +79,33 @@ async fn version(_data: web::Data<AppState>) -> impl Responder {
 // to test
 // curl -X POST -d 'txt=txt' 127.0.0.1:8080/echo
 #[post("/tx/raw")]
-async fn broadcast_tx(hexstr: String, data: web::Data<AppState>) -> Result<impl Responder> {
+async fn broadcast_tx(
+    hexstr: String,
+    req: HttpRequest,
+    data: web::Data<AppState>,
+) -> Result<HttpResponse> {
+    if let Some(response) = authorize(&req, &data.api_key) {
+        return Ok(response);
+    }
+
     // decode the hexstr to tx
     let bytes = match decode_hexstr(&hexstr) {
         Ok(b) => b,
         Err(_) => {
-            let response = BroadcastTxResponse {
+            return Ok(HttpResponse::Ok().json(BroadcastTxResponse {
                 status: "Failed".to_string(),
                 detail: "Failed to decode hex".to_string(),
-            };
-            return Ok(web::Json(response));
+            }));
         }
     };
 
     let tx = match Tx::read(&mut Cursor::new(&bytes)) {
         Ok(tx) => tx,
         Err(_) => {
-            let response = BroadcastTxResponse {
+            return Ok(HttpResponse::Ok().json(BroadcastTxResponse {
                 status: "Failed".to_string(),
                 detail: "Failed to convert hex to tx".to_string(),
-            };
-            return Ok(web::Json(response));
+            }));
         }
     };
 
@@ -93,27 +118,29 @@ async fn broadcast_tx(hexstr: String, data: web::Data<AppState>) -> Result<impl 
         .is_err()
     {
         log::error!("REST API channel closed; cannot broadcast transaction");
-        let response = BroadcastTxResponse {
+        return Ok(HttpResponse::Ok().json(BroadcastTxResponse {
             status: "Failed".to_string(),
             detail: "Service unavailable".to_string(),
-        };
-        return Ok(web::Json(response));
+        }));
     }
 
     // Return hash as hex_str, if successful
-    let response = BroadcastTxResponse {
+    Ok(HttpResponse::Ok().json(BroadcastTxResponse {
         status: "Success".to_string(),
         detail: hash,
-    };
-
-    Ok(web::Json(response))
+    }))
 }
 
 #[post("/collection/monitor")]
 async fn add_monitor(
     monitor: web::Json<CollectionConfig>,
+    req: HttpRequest,
     data: web::Data<AppState>,
 ) -> Result<impl Responder> {
+    if let Some(response) = authorize(&req, &data.api_key) {
+        return Ok(response);
+    }
+
     log::info!("add_monitor");
 
     let cc = monitor.into_inner();
@@ -133,8 +160,13 @@ async fn add_monitor(
 #[delete("/collection/monitor/{monitor_name}")]
 async fn delete_monitor(
     monitor_name: web::Path<String>,
+    req: HttpRequest,
     data: web::Data<AppState>,
 ) -> Result<impl Responder> {
+    if let Some(response) = authorize(&req, &data.api_key) {
+        return Ok(response);
+    }
+
     log::info!("delete_monitor '{}'", &monitor_name);
 
     if data


### PR DESCRIPTION
## Summary
- Add optional `api_key` under `[web_interface]` in config
- When set, require `X-API-Key` header on Python REST endpoints (except `GET /health` and CORS preflight)
- Enforce the same key on Rust mutating routes: `POST /tx/raw`, collection monitor add/delete
- Python forwards the key automatically when proxying to Rust
- Add `docs/Security.md` and update README / Configuration docs with network binding guidance

Backward compatible: auth is disabled when `api_key` is omitted (default).

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test`
- [x] `./lint.sh`
- [ ] With `api_key` unset, existing clients work unchanged
- [ ] With `api_key` set, requests without header return 401; `/health` still returns 200
- [ ] `curl -H "X-API-Key: ..." .../status` succeeds with key configured


Made with [Cursor](https://cursor.com)