### PR TITLE
Use parameterized SQL in Rust database layer

### DIFF
--- a/rust/src/uaas/collection.rs
+++ b/rust/src/uaas/collection.rs
@@ -59,11 +59,14 @@ impl CollectionDatabase {
     pub fn load_txs(&mut self, collection_name: &str) -> Vec<Hash256> {
         // load txs- tx hash from database
         let start = Instant::now();
-        let table = format!(
-            "SELECT hash FROM collection WHERE name = '{}';",
-            collection_name
-        );
-        let txs: Vec<String> = self.conn.query_map(table, |hash| hash).unwrap();
+        let txs: Vec<String> = self
+            .conn
+            .exec_map(
+                "SELECT hash FROM collection WHERE name = :name",
+                params! { "name" => collection_name },
+                |hash| hash,
+            )
+            .unwrap();
 
         let retval: Vec<Hash256> = txs.iter().map(|x| Hash256::decode(x).unwrap()).collect();
 
@@ -83,14 +86,18 @@ impl CollectionDatabase {
         tx.write(&mut b).unwrap();
         let tx_hex = format!("{}", HexSlice::new(&b));
 
-        let collection_insert = format!(
-            "INSERT INTO collection VALUES ('{}', '{}', '{}');",
-            &hash, collection_name, tx_hex,
-        );
-
         let result = retry(
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
-            || self.conn.exec_drop(&collection_insert, Params::Empty),
+            || {
+                self.conn.exec_drop(
+                    "INSERT INTO collection (hash, name, tx) VALUES (:hash, :name, :tx)",
+                    params! {
+                        "hash" => hash.as_str(),
+                        "name" => collection_name,
+                        "tx" => tx_hex.as_str(),
+                    },
+                )
+            },
         );
         result.unwrap();
     }

--- a/rust/src/uaas/database.rs
+++ b/rust/src/uaas/database.rs
@@ -161,26 +161,29 @@ impl Database {
     }
 
     fn mempool_write(&mut self, mempool_entry: MempoolEntryDB) {
-        let mempool_insert = format!(
-            "INSERT INTO mempool VALUES ('{}', {}, {}, {},'{}');",
-            &mempool_entry.hash.encode(),
-            &mempool_entry.locktime,
-            &mempool_entry.fee,
-            &mempool_entry.age,
-            &mempool_entry.tx,
-        );
+        let hash = mempool_entry.hash.encode();
+        let locktime = mempool_entry.locktime;
+        let fee = mempool_entry.fee;
+        let age = mempool_entry.age;
+        let tx = mempool_entry.tx;
 
         let result = retry(
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
-            || self.conn.exec_drop(&mempool_insert, Params::Empty),
+            || {
+                self.conn.exec_drop(
+                    "INSERT INTO mempool (hash, locktime, fee, time, tx) \
+                     VALUES (:hash, :locktime, :fee, :time, :tx)",
+                    params! {
+                        "hash" => hash.as_str(),
+                        "locktime" => locktime,
+                        "fee" => fee,
+                        "time" => age,
+                        "tx" => tx.as_str(),
+                    },
+                )
+            },
         );
         result.unwrap();
-        /*
-        // Write mempool entry to database
-        self.conn.exec_drop(&mempool_insert, Params::Empty).expect(
-            "Problem writing to mempool table. Check that tx field is present in mempool table.\n",
-        );
-        */
     }
 
     fn mempool_batch_delete(&mut self, mempool_hashes: Vec<Hash256>) {
@@ -199,51 +202,80 @@ impl Database {
     }
 
     fn block_header_write(&mut self, block_header: BlockHeaderWriteDB) {
-        let blocks_insert = format!(
-            "INSERT INTO blocks
-            VALUES ({}, '{}', {}, '{}', '{}', {}, {}, {}, {}, {}, {});",
-            block_header.height,
-            block_header.hash.encode(),
-            block_header.version,
-            block_header.prev_hash.encode(),
-            block_header.merkle_root.encode(),
-            block_header.timestamp,
-            block_header.bits,
-            block_header.nonce,
-            block_header.position,
-            block_header.blocksize,
-            block_header.numtxs,
-        );
+        let height = block_header.height;
+        let hash = block_header.hash.encode();
+        let version = block_header.version;
+        let prev_hash = block_header.prev_hash.encode();
+        let merkle_root = block_header.merkle_root.encode();
+        let timestamp = block_header.timestamp;
+        let bits = block_header.bits;
+        let nonce = block_header.nonce;
+        let position = block_header.position;
+        let blocksize = block_header.blocksize;
+        let numtxs = block_header.numtxs;
+
         let result = retry(
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
-            || self.conn.exec_drop(&blocks_insert, Params::Empty),
+            || {
+                self.conn.exec_drop(
+                    r"INSERT INTO blocks
+                    (height, hash, version, prev_hash, merkle_root, timestamp, bits, nonce, `offset`, blocksize, numtxs)
+                    VALUES (:height, :hash, :version, :prev_hash, :merkle_root, :timestamp, :bits, :nonce, :offset, :blocksize, :numtxs)",
+                    params! {
+                        "height" => height,
+                        "hash" => hash.as_str(),
+                        "version" => version,
+                        "prev_hash" => prev_hash.as_str(),
+                        "merkle_root" => merkle_root.as_str(),
+                        "timestamp" => timestamp,
+                        "bits" => bits,
+                        "nonce" => nonce,
+                        "offset" => position,
+                        "blocksize" => blocksize,
+                        "numtxs" => numtxs,
+                    },
+                )
+            },
         );
         result.unwrap();
     }
 
     fn block_header_delete(&mut self, hash: &Hash256) {
-        let block_delete = format!("DELETE FROM blocks WHERE hash = '{}';", hash.encode());
+        let hash = hash.encode();
         let result = retry(
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
-            || self.conn.exec_drop(&block_delete, Params::Empty),
+            || {
+                self.conn.exec_drop(
+                    "DELETE FROM blocks WHERE hash = :hash",
+                    params! { "hash" => hash.as_str() },
+                )
+            },
         );
         result.unwrap();
     }
 
     fn tx_delete_at_height(&mut self, height: u32) {
-        let tx_delete = format!("DELETE FROM tx WHERE height = '{}';", height);
         let result = retry(
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
-            || self.conn.exec_drop(&tx_delete, Params::Empty),
+            || {
+                self.conn.exec_drop(
+                    "DELETE FROM tx WHERE height = :height",
+                    params! { "height" => height },
+                )
+            },
         );
         result.unwrap();
     }
 
     fn utxo_delete_at_height(&mut self, height: u32) {
-        let utxo_delete = format!("DELETE FROM utxo WHERE height = '{}';", height);
         let result = retry(
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
-            || self.conn.exec_drop(&utxo_delete, Params::Empty),
+            || {
+                self.conn.exec_drop(
+                    "DELETE FROM utxo WHERE height = :height",
+                    params! { "height" => height },
+                )
+            },
         );
         result.unwrap();
     }


### PR DESCRIPTION
## Summary
- Replace `format!`-built SQL in `database.rs` with `params!` for:
  - mempool inserts
  - block header inserts and deletes
  - tx/utxo deletes by height
- Replace string-interpolated SQL in `collection.rs` with parameterized `SELECT` and `INSERT`

Aligns the Rust DB layer with the parameterized approach already used in Python (`database.py`) and in existing Rust batch writes.

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test`
- [ ] Run IBD or block processing against MariaDB and confirm blocks/mempool/collection data writes correctly


Made with [Cursor](https://cursor.com)