### PR TITLE
Improve error handling in remaining Rust DB modules

### DIFF
--- a/rust/src/dynamic_config.rs
+++ b/rust/src/dynamic_config.rs
@@ -26,7 +26,8 @@ fn save_dynamic_config(filename: &str, clients: &[CollectionConfig]) -> std::io:
     let config = DynamicConfigConfig {
         collection: clients.to_vec(),
     };
-    let content = toml::to_string(&config).unwrap();
+    let content =
+        toml::to_string(&config).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     std::fs::write(filename, content)?;
     Ok(())
 }
@@ -66,6 +67,11 @@ impl DynamicConfig {
     }
 
     fn save(&self) {
-        save_dynamic_config(&self.filename, &self.collection).unwrap();
+        if let Err(err) = save_dynamic_config(&self.filename, &self.collection) {
+            log::error!(
+                "Unable to save dynamic config to {}: {err:?}",
+                self.filename
+            );
+        }
     }
 }

--- a/rust/src/event_handler.rs
+++ b/rust/src/event_handler.rs
@@ -31,24 +31,28 @@ impl EventHandler {
     }
 
     pub fn get_elapsed_time(&self) -> f64 {
-        // Return how much time has passed since last message
-        let x = self.last_event.lock().unwrap();
+        let x = self.last_event.lock().unwrap_or_else(|e| e.into_inner());
         x.elapsed().as_secs_f64()
     }
 
     pub fn set_connected(&self, connected: bool) {
-        let mut connected_to_peer = self.connected_to_peer.lock().unwrap();
+        let mut connected_to_peer = self
+            .connected_to_peer
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         *connected_to_peer = connected;
     }
 
     pub fn get_connected(&self) -> bool {
-        let connected_to_peer = self.connected_to_peer.lock().unwrap();
+        let connected_to_peer = self
+            .connected_to_peer
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         *connected_to_peer
     }
 
     fn update_timer(&self) {
-        // Update the last message event timer, this is called whenever a event is received
-        let mut x = self.last_event.lock().unwrap();
+        let mut x = self.last_event.lock().unwrap_or_else(|e| e.into_inner());
         *x = time::Instant::now();
     }
 
@@ -142,16 +146,20 @@ impl Observer<PeerConnected> for EventHandler {
         // On connected
         self.update_timer();
 
-        let version = event.peer.version().expect("failed to get version!");
-        self.set_connected(true);
+        let detail = match event.peer.version() {
+            Ok(version) => format!(
+                "user_agent={}, services={:x} ({:?})",
+                version.user_agent,
+                version.tx_addr.services,
+                decode_services(version.tx_addr.services)
+            ),
+            Err(err) => {
+                log::warn!("Failed to get peer version from {}: {err:?}", event.peer.ip);
+                format!("peer={}", event.peer.ip)
+            }
+        };
 
-        // dbg!(&version);
-        let detail = format!(
-            "user_agent={}, services={:x} ({:?})",
-            version.user_agent,
-            version.tx_addr.services,
-            decode_services(version.tx_addr.services)
-        );
+        self.set_connected(true);
 
         let msg = PeerEventMessage {
             time: time::SystemTime::now(),

--- a/rust/src/uaas/address_manager.rs
+++ b/rust/src/uaas/address_manager.rs
@@ -24,69 +24,82 @@ impl AddressManager {
     }
 
     fn create_table(&mut self) {
-        // Create tables, if required
-
-        // Check for the tables
-        let tables: Vec<String> = self
-            .conn
-            .query(
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
-            )
-            .unwrap();
+        let tables: Vec<String> = match self.conn.query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
+        ) {
+            Ok(tables) => tables,
+            Err(err) => {
+                log::error!("Unable to list database tables for addr manager: {err:?}");
+                return;
+            }
+        };
 
         if !tables.iter().any(|x| x.as_str() == "addr") {
             log::info!("Table addr not found - creating");
-            self.conn
+            if let Err(err) = self
+                .conn
                 .query_drop("CREATE TABLE addr (ip text, services int, port int);")
-                .unwrap();
+            {
+                log::error!("Unable to create addr table: {err:?}");
+            }
         }
     }
 
     fn read_table(&mut self) {
-        // Read the contents of the database into vec so that we can check for duplicates
-        let contents = self
-            .conn
-            .query_map("SELECT ip  FROM addr", |ip: String| ip)
-            .unwrap();
+        let contents = match self.conn.query_map("SELECT ip  FROM addr", |ip: String| ip) {
+            Ok(contents) => contents,
+            Err(err) => {
+                log::error!("Unable to load addr table: {err:?}");
+                return;
+            }
+        };
         for c in contents {
             self.addresses.push(c);
         }
     }
 
     pub fn setup(&mut self) {
-        // Do startup setup stuff
         self.create_table();
         self.read_table();
     }
 
     pub fn on_addr(&mut self, addr: Addr) {
-        // On receiving an Addr message
-        let addr_insert = self
+        let addr_insert = match self
             .conn
             .prep("INSERT INTO addr (ip, services, port) VALUES (:ip, :services, :port)")
-            .unwrap();
-        // Got this once, keep an eye to see if occurs more often
-        // This appears to be a mysql connection issue
-        // Could potentially be caused by the fact that this is the first mysql call made by the service
-        // thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CodecError { Packets out of sync }', src/uaas/address_manager.rs:61:14
+        {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                log::error!("Unable to prepare addr insert statement: {err:?}");
+                return;
+            }
+        };
 
         for address in addr.addrs.iter() {
-            // Check to see if we have seen this address already
             if !self
                 .addresses
                 .iter()
                 .any(|x| x == &format!("{}", address.addr.ip))
             {
-                // if not add it to the table
                 let ip_addr = format!("{}", address.addr.ip);
 
                 let result = retry(
                     delay::Fixed::from_millis(self.ms_delay).take(self.retries),
                     || {
-                        self.conn.exec_drop(&addr_insert, params! { "ip" => ip_addr.clone() , "services" => address.addr.services, "port" => address.addr.port})
+                        self.conn.exec_drop(
+                            &addr_insert,
+                            params! {
+                                "ip" => ip_addr.clone(),
+                                "services" => address.addr.services,
+                                "port" => address.addr.port
+                            },
+                        )
                     },
                 );
-                result.unwrap();
+                if let Err(err) = result {
+                    log::error!("Unable to insert addr {ip_addr}: {err:?}");
+                    continue;
+                }
 
                 self.addresses.push(ip_addr);
             }

--- a/rust/src/uaas/collection.rs
+++ b/rust/src/uaas/collection.rs
@@ -49,30 +49,50 @@ impl CollectionDatabase {
         }
     }
 
+    fn decode_stored_hash(value: &str) -> Option<Hash256> {
+        match Hash256::decode(value) {
+            Ok(hash) => Some(hash),
+            Err(err) => {
+                log::error!("Invalid stored collection tx hash {value}: {err:?}");
+                None
+            }
+        }
+    }
+
     pub fn create_table(&self, conn: &mut PooledConn) {
         log::info!("Table collection not found - creating");
 
         let table = "CREATE TABLE collection (hash varchar(64), name varchar(64), tx longtext, CONSTRAINT PK_Entry PRIMARY KEY (hash, name));";
-        conn.query_drop(table).unwrap();
+        if let Err(err) = conn.query_drop(table) {
+            log::error!("Unable to create collection table: {err:?}");
+            return;
+        }
 
-        // create index
         let index = "CREATE INDEX collect_key ON collection (hash, name);";
-        conn.query_drop(index).unwrap();
+        if let Err(err) = conn.query_drop(index) {
+            log::error!("Unable to create collection index: {err:?}");
+        }
     }
 
     pub fn load_txs(&mut self, collection_name: &str) -> Vec<Hash256> {
         // load txs- tx hash from database
         let start = Instant::now();
-        let txs: Vec<String> = self
-            .conn
-            .exec_map(
-                "SELECT hash FROM collection WHERE name = :name",
-                params! { "name" => collection_name },
-                |hash| hash,
-            )
-            .unwrap();
+        let txs: Vec<String> = match self.conn.exec_map(
+            "SELECT hash FROM collection WHERE name = :name",
+            params! { "name" => collection_name },
+            |hash| hash,
+        ) {
+            Ok(txs) => txs,
+            Err(err) => {
+                log::error!("Unable to load collection txs for {collection_name}: {err:?}");
+                return Vec::new();
+            }
+        };
 
-        let retval: Vec<Hash256> = txs.iter().map(|x| Hash256::decode(x).unwrap()).collect();
+        let retval: Vec<Hash256> = txs
+            .iter()
+            .filter_map(|hash| Self::decode_stored_hash(hash))
+            .collect();
 
         log::info!(
             "Collection {} Loaded {} in {} seconds",
@@ -87,7 +107,10 @@ impl CollectionDatabase {
         let hash = tx.hash().encode();
         // Write the tx as hexstr
         let mut b = Vec::with_capacity(tx.size());
-        tx.write(&mut b).unwrap();
+        if let Err(err) = tx.write(&mut b) {
+            log::error!("Unable to serialize collection tx {hash}: {err:?}");
+            return;
+        }
         let tx_hex = format!("{}", HexSlice::new(&b));
 
         let result = retry(
@@ -103,7 +126,9 @@ impl CollectionDatabase {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            log::error!("Unable to write collection tx {hash} for {collection_name}: {err:?}");
+        }
     }
 }
 

--- a/rust/src/uaas/connection.rs
+++ b/rust/src/uaas/connection.rs
@@ -22,37 +22,41 @@ impl Connection {
     }
 
     fn create_table(&mut self) {
-        // Create tables, if required
-
-        // Check for the tables
-        let tables: Vec<String> = self
-            .conn
-            .query(
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
-            )
-            .unwrap();
+        let tables: Vec<String> = match self.conn.query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
+        ) {
+            Ok(tables) => tables,
+            Err(err) => {
+                log::error!("Unable to list database tables for connect log: {err:?}");
+                return;
+            }
+        };
 
         if !tables.iter().any(|x| x.as_str() == "connect") {
             log::info!("Table connect not found - creating");
-            self.conn
-                .query_drop(
-                    "CREATE TABLE connect (date VARCHAR(64), ip VARCHAR(64), event VARCHAR(64));",
-                )
-                .unwrap();
+            if let Err(err) = self.conn.query_drop(
+                "CREATE TABLE connect (date VARCHAR(64), ip VARCHAR(64), event VARCHAR(64));",
+            ) {
+                log::error!("Unable to create connect table: {err:?}");
+            }
         }
     }
 
     pub fn setup(&mut self) {
-        // Do startup setup stuff
         self.create_table();
     }
 
     fn insert_data(&mut self, ip: &IpAddr, event: &str) {
-        // On receiving an Connect or Disconnect message, write it to the database
-        let connect_insert = self
+        let connect_insert = match self
             .conn
             .prep("INSERT INTO connect (date, ip, event) VALUES (:date, :ip, :event)")
-            .unwrap();
+        {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                log::error!("Unable to prepare connect insert statement: {err:?}");
+                return;
+            }
+        };
 
         let date = Utc::now();
         let date_str = date.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -61,12 +65,18 @@ impl Connection {
             delay::Fixed::from_millis(self.ms_delay).take(self.retries),
             || {
                 self.conn.exec_drop(
-                &connect_insert,
-                params! { "date" => date_str.clone() , "ip" => ip.to_string(), "event" => event},
-            )
+                    &connect_insert,
+                    params! {
+                        "date" => date_str.clone(),
+                        "ip" => ip.to_string(),
+                        "event" => event
+                    },
+                )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            log::error!("Unable to write connect event for {ip}: {err:?}");
+        }
     }
 
     pub fn on_connect(&mut self, ip: &IpAddr) {

--- a/rust/src/uaas/database.rs
+++ b/rust/src/uaas/database.rs
@@ -108,6 +108,10 @@ impl Database {
         }
     }
 
+    fn log_write_error(operation: &str, err: impl std::fmt::Debug) {
+        log::error!("Database write failed during {operation}: {err:?}");
+    }
+
     fn utxo_batch_write(&mut self, utxo_entries: Vec<UtxoEntryDB>) {
         // bulk/batch write tx output to utxo table
 
@@ -125,7 +129,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("utxo batch write", err);
+        }
     }
 
     fn utxo_batch_delete(&mut self, utxo_deletes: Vec<OutPoint>) {
@@ -141,7 +147,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("utxo batch delete", err);
+        }
     }
 
     fn tx_batch_write(&mut self, tx_entries: Vec<TxEntryWriteDB>) {
@@ -157,7 +165,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("tx batch write", err);
+        }
     }
 
     fn mempool_write(&mut self, mempool_entry: MempoolEntryDB) {
@@ -183,7 +193,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("mempool write", err);
+        }
     }
 
     fn mempool_batch_delete(&mut self, mempool_hashes: Vec<Hash256>) {
@@ -198,7 +210,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("mempool batch delete", err);
+        }
     }
 
     fn block_header_write(&mut self, block_header: BlockHeaderWriteDB) {
@@ -237,7 +251,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("block header write", err);
+        }
     }
 
     fn block_header_delete(&mut self, hash: &Hash256) {
@@ -251,7 +267,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("block header delete", err);
+        }
     }
 
     fn tx_delete_at_height(&mut self, height: u32) {
@@ -264,7 +282,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("tx delete at height", err);
+        }
     }
 
     fn utxo_delete_at_height(&mut self, height: u32) {
@@ -277,7 +297,9 @@ impl Database {
                 )
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("utxo delete at height", err);
+        }
     }
 
     fn orphan_block_header_write(&mut self, block_header: OrphanBlockHeaderWriteDB) {
@@ -300,7 +322,9 @@ impl Database {
                     })
             },
         );
-        result.unwrap();
+        if let Err(err) = result {
+            Self::log_write_error("orphan block header write", err);
+        }
     }
 
     pub fn perform_db_operations(&mut self) {

--- a/rust/src/uaas/logic.rs
+++ b/rust/src/uaas/logic.rs
@@ -1,6 +1,6 @@
 use std::{sync::mpsc, thread};
 
-use mysql::Pool;
+use mysql::{Pool, PooledConn};
 
 use chain_gang::{
     messages::{Addr, Block, BlockLocator, Headers, Inv, InvVect, Message, Tx},
@@ -57,15 +57,31 @@ pub struct Logic {
 }
 
 impl Logic {
-    pub fn new(config: &Config) -> Self {
-        // Set up database connections for the components
-        let pool = Pool::new(config.get_mysql_url())
-            .expect("Problem connecting to database. Check database is connected and database connection configuration is correct.\n");
+    fn pool_conn(pool: &Pool, label: &str) -> PooledConn {
+        match pool.get_conn() {
+            Ok(conn) => conn,
+            Err(err) => {
+                log::error!("Unable to get {label} database connection: {err:?}");
+                panic!("Unable to get {label} database connection");
+            }
+        }
+    }
 
-        let block_conn = pool.get_conn().unwrap();
-        let addr_conn = pool.get_conn().unwrap();
-        let connection_conn = pool.get_conn().unwrap();
-        let db_conn = pool.get_conn().unwrap();
+    pub fn new(config: &Config) -> Self {
+        let pool = match Pool::new(config.get_mysql_url()) {
+            Ok(pool) => pool,
+            Err(err) => {
+                log::error!(
+                    "Problem connecting to database. Check database is connected and configuration is correct: {err:?}"
+                );
+                panic!("Problem connecting to database. Check database is connected and database connection configuration is correct.");
+            }
+        };
+
+        let block_conn = Self::pool_conn(&pool, "block");
+        let addr_conn = Self::pool_conn(&pool, "address");
+        let connection_conn = Self::pool_conn(&pool, "connection");
+        let db_conn = Self::pool_conn(&pool, "database writer");
 
         // Channel for database writes
         let (tx, rx) = mpsc::channel();

--- a/rust/src/uaas/tx_analyser.rs
+++ b/rust/src/uaas/tx_analyser.rs
@@ -54,17 +54,30 @@ pub struct TxAnalyser {
 }
 
 impl TxAnalyser {
+    fn pool_conn(pool: &Pool, label: &str) -> PooledConn {
+        match pool.get_conn() {
+            Ok(conn) => conn,
+            Err(err) => {
+                log::error!("Unable to get {label} database connection: {err:?}");
+                panic!("Unable to get {label} database connection");
+            }
+        }
+    }
+
     pub fn new(config: &Config, pool: Pool, tx: mpsc::Sender<DBOperationType>) -> Self {
-        // database connections
-        let tx_conn = pool.get_conn().unwrap();
-        let utxo_conn = pool.get_conn().unwrap();
-        let txdb_conn = pool.get_conn().unwrap();
-        let collection_conn = pool.get_conn().unwrap();
+        let tx_conn = Self::pool_conn(&pool, "tx analyser");
+        let utxo_conn = Self::pool_conn(&pool, "utxo");
+        let txdb_conn = Self::pool_conn(&pool, "txdb");
+        let collection_conn = Self::pool_conn(&pool, "collection");
 
         let save_txs = config.get_network_settings().save_txs;
-        let network = config
-            .get_network()
-            .expect("invalid network in config; expected mainnet, testnet, or stn");
+        let network = match config.get_network() {
+            Ok(network) => network,
+            Err(err) => {
+                log::error!("Invalid network in config: {err}");
+                panic!("invalid network in config; expected mainnet, testnet, or stn");
+            }
+        };
         let dynamic_config = DynamicConfig::new(config);
         let mut collection: Vec<WorkingCollection> = Vec::new();
 
@@ -100,14 +113,15 @@ impl TxAnalyser {
     }
 
     fn create_tables(&mut self) {
-        // Create tables, if required
-        // Check for the tables
-        let tables: Vec<String> = self
-            .conn
-            .query(
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
-            )
-            .unwrap();
+        let tables: Vec<String> = match self.conn.query(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
+        ) {
+            Ok(tables) => tables,
+            Err(err) => {
+                log::error!("Unable to list database tables for tx analyser: {err:?}");
+                return;
+            }
+        };
 
         if self.save_txs && !tables.iter().any(|x| x.as_str() == "tx") {
             self.txdb.create_tx_table();


### PR DESCRIPTION
## Summary
- **`database.rs`**: log failed retry writes instead of `unwrap()` in the background DB thread
- **`collection.rs`**: log table create, load, serialize, and insert failures; skip invalid stored hashes
- **`address_manager.rs`** / **`connection.rs`**: log query/prep/insert failures and continue
- **`dynamic_config.rs`**: propagate TOML serialize errors; log save failures
- **`tx_analyser.rs`**: log table-list failures; clearer startup connection errors
- **`event_handler.rs`**: poison-safe mutex locks; log missing peer version instead of `expect`
- **`logic.rs`**: log database pool/connection failures before startup panic

Startup still fails fast if the database is unreachable (service cannot run without it), but runtime DB paths now degrade with logging instead of panicking.

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test`
- [ ] Run sync against testnet and confirm addr/connect/collection writes still persist


Made with [Cursor](https://cursor.com)