### PR TITLE
Replace startup unwraps with Result-based error handling

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,4 +1,4 @@
-use chain_gang::network::Network;
+use chain_gang::{network::Network, util::Hash256};
 use serde::{Deserialize, Serialize};
 use std::{env, io, net::IpAddr};
 
@@ -86,24 +86,44 @@ impl Config {
         }
     }
 
-    pub fn get_network_settings(&self) -> &NetworkSettings {
+    pub fn get_network_settings(&self) -> Result<&NetworkSettings, &'static str> {
         match self.service.network.as_str() {
-            "mainnet" => &self.mainnet,
-            "testnet" => &self.testnet,
-            "stn" => panic!("no settings for STN"),
-            _ => panic!("unable to decode network"),
+            "mainnet" => Ok(&self.mainnet),
+            "testnet" => Ok(&self.testnet),
+            "stn" => Err("no settings for STN"),
+            _ => Err("unable to decode network"),
         }
     }
 
-    pub fn get_ips(&self) -> Result<Vec<IpAddr>, &str> {
+    pub fn get_ips(&self) -> Result<Vec<IpAddr>, String> {
         let mut ip_list: Vec<IpAddr> = Vec::new();
-        for ip in self.get_network_settings().ip.iter() {
-            match ip.parse() {
-                Ok(value) => ip_list.push(value),
-                Err(_) => return Err("unable to parse ip address"),
-            }
+        for ip in self
+            .get_network_settings()
+            .map_err(|e| e.to_string())?
+            .ip
+            .iter()
+        {
+            ip.parse()
+                .map(|value| ip_list.push(value))
+                .map_err(|_| format!("unable to parse ip address '{ip}'"))?;
         }
         Ok(ip_list)
+    }
+
+    pub fn validate_startup(&self) -> Result<(), String> {
+        let settings = self.get_network_settings().map_err(|err| err.to_string())?;
+        if settings.ip.is_empty() {
+            return Err("network ip list must not be empty".into());
+        }
+        self.get_ips()?;
+        self.get_network().map_err(|err| err.to_string())?;
+        Hash256::decode(&settings.start_block_hash).map_err(|err| {
+            format!(
+                "invalid start_block_hash '{}': {err:?}",
+                settings.start_block_hash
+            )
+        })?;
+        Ok(())
     }
 
     pub fn get_mysql_url(&self) -> &str {
@@ -139,25 +159,15 @@ fn read_config(filename: &str) -> std::io::Result<Config> {
 // BNAR_CONFIG='{"user_agent": "/Bitcoin SV:1.0.9/","ip": ["18.157.234.254",  "65.21.201.45" ], "port": 8333, "network": "Mainnet", "timeout_period": 60.0}'
 // cargo run
 
-pub fn get_config(env_var: &str, filename: &str) -> Option<Config> {
-    // read config try env var, then filename, panic if fails
-
+pub fn get_config(env_var: &str, filename: &str) -> Result<Config, String> {
     match env::var_os(env_var) {
         Some(content) => {
-            let val = content.into_string().unwrap();
-            // Parse to Config
-            match serde_json::from_str(&val) {
-                Ok(config) => Some(config),
-                Err(e) => panic!("Error parsing JSON environment var {:?}", e),
-            }
+            let val = content
+                .into_string()
+                .map_err(|_| format!("environment variable {env_var} contains invalid UTF-8"))?;
+            serde_json::from_str(&val)
+                .map_err(|err| format!("error parsing JSON environment variable {env_var}: {err}"))
         }
-        None => {
-            // Read config
-            let config = match read_config(filename) {
-                Ok(config) => config,
-                Err(error) => panic!("Error reading config file {:?}", error),
-            };
-            Some(config)
-        }
+        None => read_config(filename).map_err(|err| format!("error reading config file: {err}")),
     }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -33,6 +33,13 @@ use crate::{
 
 #[actix_web::main]
 async fn main() {
+    if let Err(err) = run().await {
+        eprintln!("Fatal startup error: {err}");
+        process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), String> {
     // Hook in our own panic handler
     let orig_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
@@ -41,13 +48,12 @@ async fn main() {
         process::exit(1);
     }));
 
-    // Read the config
-    let config = match get_config("UAASR_CONFIG", "../data/uaasr.toml") {
-        Some(config) => config,
-        None => panic!("Unable to read config"),
-    };
+    let config = get_config("UAASR_CONFIG", "../data/uaasr.toml")?;
 
-    simple_logger::init_with_level(config.get_log_level()).unwrap();
+    simple_logger::init_with_level(config.get_log_level())
+        .map_err(|err| format!("failed to initialize logger: {err}"))?;
+
+    config.validate_startup()?;
 
     // Get web server address from config
     let server_address = config.service.rust_address.clone();
@@ -61,7 +67,7 @@ async fn main() {
     let web_state = web::Data::new(app_state);
 
     // Setup logic
-    let mut logic = Logic::new(&config);
+    let mut logic = Logic::new(&config)?;
     logic.setup();
 
     // Used to track peer connection threads
@@ -69,10 +75,7 @@ async fn main() {
     let mut manager = ThreadManager::new(rx_rest);
     let tx = manager.get_tx();
 
-    // Decode config
-    let ips: Vec<IpAddr> = config
-        .get_ips()
-        .expect("Error decoding config ip addresses");
+    let ips = config.get_ips()?;
 
     // Start the peer threads
     let handle = thread::spawn(move ||
@@ -96,8 +99,8 @@ async fn main() {
             .service(delete_monitor)
     })
     .workers(1)
-    .bind(server_address)
-    .unwrap()
+    .bind(&server_address)
+    .map_err(|err| format!("failed to bind web server to {server_address}: {err}"))?
     .run();
 
     let server_handle = server.handle();
@@ -117,27 +120,36 @@ async fn main() {
         server_handle.stop(true).await;
     });
 
-    server.await.unwrap();
+    server
+        .await
+        .map_err(|err| format!("web server error: {err}"))?;
 
     // Wait for peer threads
     if let Err(e) = handle.join() {
         log::error!("Peer manager thread panicked during shutdown: {:?}", e);
     }
+
+    Ok(())
 }
 
 async fn wait_for_shutdown_signal() {
     let ctrl_c = async {
-        signal::ctrl_c()
-            .await
-            .expect("failed to install Ctrl+C handler");
+        if let Err(err) = signal::ctrl_c().await {
+            log::error!("failed to install Ctrl+C handler: {err}");
+        }
     };
 
     #[cfg(unix)]
     let terminate = async {
-        signal::unix::signal(signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
+        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+            Ok(mut stream) => {
+                stream.recv().await;
+            }
+            Err(err) => {
+                log::error!("failed to install SIGTERM handler: {err}");
+                std::future::pending::<()>().await;
+            }
+        }
     };
 
     #[cfg(not(unix))]

--- a/rust/src/peer_connection.rs
+++ b/rust/src/peer_connection.rs
@@ -24,8 +24,14 @@ pub struct PeerConnection {
 
 impl PeerConnection {
     pub fn new(ip: IpAddr, config: &Config, tx: mpsc::Sender<PeerEventMessage>) -> Self {
-        let port = config.get_network_settings().port;
-        let network = config.get_network().expect("Error decoding config network");
+        // Config is validated in main before peer threads are started.
+        let settings = config
+            .get_network_settings()
+            .expect("config must pass validate_startup before peer connections");
+        let port = settings.port;
+        let network = config
+            .get_network()
+            .expect("config must pass validate_startup before peer connections");
         let user_agent = &config.service.user_agent;
 
         let mut rng = rand::rng();

--- a/rust/src/thread_manager.rs
+++ b/rust/src/thread_manager.rs
@@ -50,7 +50,11 @@ impl ThreadManager {
         let peer_running = local_running.clone();
 
         // Read config
-        let timeout_period = config.get_network_settings().timeout_period;
+        // Config is validated in main before peer threads are started.
+        let timeout_period = config
+            .get_network_settings()
+            .expect("config must pass validate_startup before peer connections")
+            .timeout_period;
 
         let peer_connection = PeerConnection::new(ip, &local_config, local_tx);
         let peer = peer_connection.peer.clone();

--- a/rust/src/uaas/block_manager.rs
+++ b/rust/src/uaas/block_manager.rs
@@ -429,23 +429,18 @@ impl BlockManager {
                         0
                     }
                 };
-                loop {
-                    match Block::read(&mut file) {
-                        Ok(block) => {
-                            self.process_read_block(block, tx_analyser, position);
-                            position = match file.stream_position() {
-                                Ok(pos) => pos,
-                                Err(err) => {
-                                    log::warn!(
-                                        "Unable to read block file stream position for {}: {err}",
-                                        &self.block_file
-                                    );
-                                    position
-                                }
-                            };
+                while let Ok(block) = Block::read(&mut file) {
+                    self.process_read_block(block, tx_analyser, position);
+                    position = match file.stream_position() {
+                        Ok(pos) => pos,
+                        Err(err) => {
+                            log::warn!(
+                                "Unable to read block file stream position for {}: {err}",
+                                &self.block_file
+                            );
+                            position
                         }
-                        Err(_) => break,
-                    }
+                    };
                 }
             }
             Err(e) => log::info!("Unable to open block file {} - {}", &self.block_file, &e),

--- a/rust/src/uaas/block_manager.rs
+++ b/rust/src/uaas/block_manager.rs
@@ -90,26 +90,32 @@ impl BlockManager {
         }
     }
 
-    pub fn new(config: &Config, conn: PooledConn, tx: mpsc::Sender<DBOperationType>) -> Self {
-        let start_block_hash = config.get_network_settings().start_block_hash.clone();
-        let last_hash_processed = Hash256::decode(&start_block_hash).unwrap_or_else(|err| {
-            panic!("Invalid start_block_hash '{start_block_hash}': {err:?}");
-        });
+    pub fn new(
+        config: &Config,
+        conn: PooledConn,
+        tx: mpsc::Sender<DBOperationType>,
+    ) -> Result<Self, String> {
+        let settings = config
+            .get_network_settings()
+            .map_err(|err| err.to_string())?;
+        let start_block_hash = settings.start_block_hash.clone();
+        let last_hash_processed = Hash256::decode(&start_block_hash)
+            .map_err(|err| format!("Invalid start_block_hash '{start_block_hash}': {err:?}"))?;
 
-        BlockManager {
+        Ok(BlockManager {
             start_block_hash,
-            startup_load_from_database: config.get_network_settings().startup_load_from_database,
-            block_file: config.get_network_settings().block_file.clone(),
-            save_blocks: config.get_network_settings().save_blocks,
+            startup_load_from_database: settings.startup_load_from_database,
+            block_file: settings.block_file.clone(),
+            save_blocks: settings.save_blocks,
             block_headers: Vec::new(),
             hash_to_index: HashMap::new(),
-            height: config.get_network_settings().start_block_height + 1,
+            height: settings.start_block_height + 1,
             last_hash_processed,
             block_queue: HashMap::new(),
             conn,
             tx,
             threshold: config.orphan.threshold,
-        }
+        })
     }
 
     fn create_tables(&mut self) {
@@ -413,11 +419,33 @@ impl BlockManager {
         // Read blocks from a file
         match OpenOptions::new().read(true).open(&self.block_file) {
             Ok(mut file) => {
-                let mut position = file.stream_position().unwrap_or(0);
-                // Success - read blocks
-                while let Ok(block) = Block::read(&mut file) {
-                    self.process_read_block(block, tx_analyser, position);
-                    position = file.stream_position().unwrap_or(position);
+                let mut position = match file.stream_position() {
+                    Ok(pos) => pos,
+                    Err(err) => {
+                        log::warn!(
+                            "Unable to read block file stream position for {}: {err}",
+                            &self.block_file
+                        );
+                        0
+                    }
+                };
+                loop {
+                    match Block::read(&mut file) {
+                        Ok(block) => {
+                            self.process_read_block(block, tx_analyser, position);
+                            position = match file.stream_position() {
+                                Ok(pos) => pos,
+                                Err(err) => {
+                                    log::warn!(
+                                        "Unable to read block file stream position for {}: {err}",
+                                        &self.block_file
+                                    );
+                                    position
+                                }
+                            };
+                        }
+                        Err(_) => break,
+                    }
                 }
             }
             Err(e) => log::info!("Unable to open block file {} - {}", &self.block_file, &e),

--- a/rust/src/uaas/logic.rs
+++ b/rust/src/uaas/logic.rs
@@ -57,39 +57,38 @@ pub struct Logic {
 }
 
 impl Logic {
-    fn pool_conn(pool: &Pool, label: &str) -> PooledConn {
-        match pool.get_conn() {
-            Ok(conn) => conn,
-            Err(err) => {
-                log::error!("Unable to get {label} database connection: {err:?}");
-                panic!("Unable to get {label} database connection");
-            }
-        }
+    fn pool_conn(pool: &Pool, label: &str) -> Result<PooledConn, String> {
+        pool.get_conn().map_err(|err| {
+            log::error!("Unable to get {label} database connection: {err:?}");
+            format!("Unable to get {label} database connection")
+        })
     }
 
-    pub fn new(config: &Config) -> Self {
-        let pool = match Pool::new(config.get_mysql_url()) {
-            Ok(pool) => pool,
-            Err(err) => {
-                log::error!(
-                    "Problem connecting to database. Check database is connected and configuration is correct: {err:?}"
-                );
-                panic!("Problem connecting to database. Check database is connected and database connection configuration is correct.");
-            }
-        };
+    pub fn new(config: &Config) -> Result<Self, String> {
+        let pool = Pool::new(config.get_mysql_url()).map_err(|err| {
+            log::error!(
+                "Problem connecting to database. Check database is connected and configuration is correct: {err:?}"
+            );
+            format!(
+                "Problem connecting to database. Check database is connected and database connection configuration is correct: {err:?}"
+            )
+        })?;
 
-        let block_conn = Self::pool_conn(&pool, "block");
-        let addr_conn = Self::pool_conn(&pool, "address");
-        let connection_conn = Self::pool_conn(&pool, "connection");
-        let db_conn = Self::pool_conn(&pool, "database writer");
+        let block_conn = Self::pool_conn(&pool, "block")?;
+        let addr_conn = Self::pool_conn(&pool, "address")?;
+        let connection_conn = Self::pool_conn(&pool, "connection")?;
+        let db_conn = Self::pool_conn(&pool, "database writer")?;
 
         // Channel for database writes
         let (tx, rx) = mpsc::channel();
 
+        let tx_analyser = TxAnalyser::new(config, pool, tx.clone())?;
+        let block_manager = BlockManager::new(config, block_conn, tx)?;
+
         let mut logic = Logic {
             state: ServerStateType::Starting,
-            tx_analyser: TxAnalyser::new(config, pool, tx.clone()),
-            block_manager: BlockManager::new(config, block_conn, tx),
+            tx_analyser,
+            block_manager,
             address_manager: AddressManager::new(config, addr_conn),
             connection: Connection::new(config, connection_conn),
 
@@ -111,7 +110,7 @@ impl Logic {
             database.perform_db_operations();
         }));
 
-        logic
+        Ok(logic)
     }
 
     pub fn setup(&mut self) {

--- a/rust/src/uaas/tx_analyser.rs
+++ b/rust/src/uaas/tx_analyser.rs
@@ -54,30 +54,28 @@ pub struct TxAnalyser {
 }
 
 impl TxAnalyser {
-    fn pool_conn(pool: &Pool, label: &str) -> PooledConn {
-        match pool.get_conn() {
-            Ok(conn) => conn,
-            Err(err) => {
-                log::error!("Unable to get {label} database connection: {err:?}");
-                panic!("Unable to get {label} database connection");
-            }
-        }
+    fn pool_conn(pool: &Pool, label: &str) -> Result<PooledConn, String> {
+        pool.get_conn().map_err(|err| {
+            log::error!("Unable to get {label} database connection: {err:?}");
+            format!("Unable to get {label} database connection")
+        })
     }
 
-    pub fn new(config: &Config, pool: Pool, tx: mpsc::Sender<DBOperationType>) -> Self {
-        let tx_conn = Self::pool_conn(&pool, "tx analyser");
-        let utxo_conn = Self::pool_conn(&pool, "utxo");
-        let txdb_conn = Self::pool_conn(&pool, "txdb");
-        let collection_conn = Self::pool_conn(&pool, "collection");
+    pub fn new(
+        config: &Config,
+        pool: Pool,
+        tx: mpsc::Sender<DBOperationType>,
+    ) -> Result<Self, String> {
+        let tx_conn = Self::pool_conn(&pool, "tx analyser")?;
+        let utxo_conn = Self::pool_conn(&pool, "utxo")?;
+        let txdb_conn = Self::pool_conn(&pool, "txdb")?;
+        let collection_conn = Self::pool_conn(&pool, "collection")?;
 
-        let save_txs = config.get_network_settings().save_txs;
-        let network = match config.get_network() {
-            Ok(network) => network,
-            Err(err) => {
-                log::error!("Invalid network in config: {err}");
-                panic!("invalid network in config; expected mainnet, testnet, or stn");
-            }
-        };
+        let save_txs = config
+            .get_network_settings()
+            .map_err(|err| err.to_string())?
+            .save_txs;
+        let network = config.get_network().map_err(|err| err.to_string())?;
         let dynamic_config = DynamicConfig::new(config);
         let mut collection: Vec<WorkingCollection> = Vec::new();
 
@@ -100,7 +98,7 @@ impl TxAnalyser {
             WorkingCollection::create_broadcast_collection();
         collection.push(broadcast_collection);
 
-        TxAnalyser {
+        Ok(TxAnalyser {
             save_txs,
             txdb: TxDB::new(txdb_conn, tx.clone(), save_txs),
             utxo: Utxo::new(utxo_conn, tx),
@@ -109,7 +107,7 @@ impl TxAnalyser {
             collection_db: CollectionDatabase::new(collection_conn, config),
             dynamic_config: dynamic_config.clone(),
             network,
-        }
+        })
     }
 
     fn create_tables(&mut self) {


### PR DESCRIPTION
## Summary
- Return `Result` from config load, network settings lookup, and startup validation instead of panicking on bad config
- Propagate startup errors through `main` (logger init, DB pool, bind, server) with a clear fatal message and exit code 1
- Return `Result` from `BlockManager::new`, `Logic::new`, and `TxAnalyser::new`; improve block file read error handling

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [ ] Start service with valid config and confirm normal startup
- [ ] Start with invalid/missing config and confirm clean failure message (no panic stack trace)


Made with [Cursor](https://cursor.com)