### PR TITLE
Add configurable broadcast transaction size limits

### DIFF
--- a/data/uaasr.toml
+++ b/data/uaasr.toml
@@ -169,6 +169,9 @@ cors_allow_credentials = false
 # Optional: require X-API-Key header on API requests (see docs/Security.md)
 # api_key = "change-me-to-a-long-random-secret"
 
+# Maximum decoded transaction size accepted by POST /tx/hex (default: 1000000)
+# max_broadcast_tx_bytes = 1000000
+
 
 [dynamic_config]
 filename = "../data/dynamic.toml"

--- a/data/uaasr.toml
+++ b/data/uaasr.toml
@@ -169,6 +169,9 @@ cors_allow_credentials = false
 # Optional: require X-API-Key header on API requests (see docs/Security.md)
 # api_key = "change-me-to-a-long-random-secret"
 
+# Per-client request limit per minute (0 = disabled)
+# rate_limit_per_minute = 120
+
 
 [dynamic_config]
 filename = "../data/dynamic.toml"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -146,6 +146,7 @@ The web interface section has the following fields:
 * `reload` - if set to true the webserver will reload if the source code is changed
 * `rust_url` - base URL of the Rust backend used for broadcast and collection monitor operations
 * `api_key` - *(optional)* when set, clients must send this value in the `X-API-Key` request header on all endpoints except `/health`. The same key is enforced on the Rust backend for mutating operations. Leave unset for local development with no authentication.
+* `max_broadcast_tx_bytes` - *(optional, default `1000000`)* maximum decoded transaction size accepted by `POST /tx/hex` and the Rust `POST /tx/raw` broadcast endpoint. Requests above this limit are rejected before parsing.
 
 For production deployments, bind the Python API to a private interface (for example `127.0.0.1:5010`) or place the service behind a reverse proxy. Do not expose the Rust API port (`8081`) or the database/admin ports to the public internet without additional network controls. See [Security](Security.md) for details.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -146,6 +146,7 @@ The web interface section has the following fields:
 * `reload` - if set to true the webserver will reload if the source code is changed
 * `rust_url` - base URL of the Rust backend used for broadcast and collection monitor operations
 * `api_key` - *(optional)* when set, clients must send this value in the `X-API-Key` request header on all endpoints except `/health`. The same key is enforced on the Rust backend for mutating operations. Leave unset for local development with no authentication.
+* `rate_limit_per_minute` - *(optional, default `0` = disabled)* maximum requests per client IP per minute on all endpoints except `/health`. Applies to both the Python and Rust REST APIs. Uses the first address in `X-Forwarded-For` when present.
 
 For production deployments, bind the Python API to a private interface (for example `127.0.0.1:5010`) or place the service behind a reverse proxy. Do not expose the Rust API port (`8081`) or the database/admin ports to the public internet without additional network controls. See [Security](Security.md) for details.
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -46,7 +46,7 @@ When `api_key` is omitted from config, authentication is disabled (default for l
 
 Even with an API key, treat the service as privileged infrastructure:
 
-- **Broadcast** (`POST /tx/hex`) relays transactions to the BSV network.
+- **Broadcast** (`POST /tx/hex`) relays transactions to the BSV network. Payload size is capped by `max_broadcast_tx_bytes` in `[web_interface]` (default 1 MiB) on both the Python and Rust APIs.
 - **Collection monitors** can capture and store arbitrary matching transactions.
 - **UTXO queries** reveal balance and transaction data for queried addresses.
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -42,6 +42,10 @@ curl -H "X-API-Key: change-me-to-a-long-random-secret" \
 
 When `api_key` is omitted from config, authentication is disabled (default for local development).
 
+## Rate limiting
+
+Set `rate_limit_per_minute` under `[web_interface]` to cap requests per client IP (per minute). `0` disables limiting (default). `/health` is always exempt so Docker healthchecks keep working. When running behind a reverse proxy, ensure `X-Forwarded-For` reflects the real client address.
+
 ## Sensitive operations
 
 Even with an API key, treat the service as privileged infrastructure:

--- a/python/src/config.py
+++ b/python/src/config.py
@@ -51,6 +51,15 @@ def _validate_config(config: ConfigType, filename: str) -> None:
             f"Config '{filename}' section [web_interface] 'api_key' must be a non-empty string when set."
         )
 
+    max_broadcast_tx_bytes = web_interface.get("max_broadcast_tx_bytes")
+    if max_broadcast_tx_bytes is not None and (
+        not isinstance(max_broadcast_tx_bytes, int) or max_broadcast_tx_bytes < 1
+    ):
+        raise ConfigError(
+            f"Config '{filename}' section [web_interface] 'max_broadcast_tx_bytes' "
+            "must be a positive integer when set."
+        )
+
 
 def load_config(filename: str) -> ConfigType:
     """Load and validate config from the provided TOML file."""

--- a/python/src/config.py
+++ b/python/src/config.py
@@ -51,6 +51,15 @@ def _validate_config(config: ConfigType, filename: str) -> None:
             f"Config '{filename}' section [web_interface] 'api_key' must be a non-empty string when set."
         )
 
+    rate_limit_per_minute = web_interface.get("rate_limit_per_minute")
+    if rate_limit_per_minute is not None and (
+        not isinstance(rate_limit_per_minute, int) or rate_limit_per_minute < 0
+    ):
+        raise ConfigError(
+            f"Config '{filename}' section [web_interface] 'rate_limit_per_minute' "
+            "must be a non-negative integer when set."
+        )
+
 
 def load_config(filename: str) -> ConfigType:
     """Load and validate config from the provided TOML file."""

--- a/python/src/rate_limit.py
+++ b/python/src/rate_limit.py
@@ -1,0 +1,41 @@
+import time
+from threading import Lock
+from typing import Dict, Tuple
+
+from starlette.requests import Request
+
+WINDOW_SECONDS = 60.0
+
+
+def client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+class FixedWindowRateLimiter:
+    """Per-client fixed-window request counter (thread-safe)."""
+
+    def __init__(self, limit_per_minute: int) -> None:
+        self.limit_per_minute = limit_per_minute
+        self._windows: Dict[str, Tuple[float, int]] = {}
+        self._lock = Lock()
+
+    def allow(self, client: str) -> bool:
+        if self.limit_per_minute == 0:
+            return True
+
+        now = time.monotonic()
+        with self._lock:
+            window_start, count = self._windows.get(client, (now, 0))
+            if now - window_start >= WINDOW_SECONDS:
+                window_start = now
+                count = 0
+            if count >= self.limit_per_minute:
+                self._windows[client] = (window_start, count)
+                return False
+            self._windows[client] = (window_start, count + 1)
+            return True

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -18,10 +18,12 @@ from collection import collection, hexstr_to_tx, Monitor
 from logic import logic
 from util import address_to_public_key_hash
 from validation import (
+    DEFAULT_MAX_BROADCAST_TX_BYTES,
     validate_tx_hash,
     validate_block_hash,
     validate_block_height,
     validate_monitor_name,
+    validate_broadcast_tx_hex,
     validate_hex_string,
 )
 
@@ -56,6 +58,9 @@ if cors_allow_credentials and "*" in cors_origins:
     cors_allow_credentials = False
 
 api_key: str | None = web_interface.get("api_key")
+max_broadcast_tx_bytes: int = web_interface.get(
+    "max_broadcast_tx_bytes", DEFAULT_MAX_BROADCAST_TX_BYTES
+)
 
 
 class ApiKeyMiddleware(BaseHTTPMiddleware):
@@ -207,7 +212,7 @@ class Tx(BaseModel):
     @field_validator("tx")
     @classmethod
     def check_tx_hex(cls, value: str) -> str:
-        return validate_hex_string(value)
+        return validate_broadcast_tx_hex(value, max_broadcast_tx_bytes)
 
 
 @app.post("/tx/hex", tags=["Tx"])

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -16,6 +16,7 @@ from tx_analyser import tx_analyser
 from block_manager import block_manager
 from collection import collection, hexstr_to_tx, Monitor
 from logic import logic
+from rate_limit import FixedWindowRateLimiter, client_ip
 from util import address_to_public_key_hash
 from validation import (
     validate_tx_hash,
@@ -56,6 +57,24 @@ if cors_allow_credentials and "*" in cors_origins:
     cors_allow_credentials = False
 
 api_key: str | None = web_interface.get("api_key")
+rate_limit_per_minute: int = web_interface.get("rate_limit_per_minute", 0)
+rate_limiter = FixedWindowRateLimiter(rate_limit_per_minute)
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if (
+            rate_limit_per_minute == 0
+            or request.method == "OPTIONS"
+            or request.url.path == "/health"
+        ):
+            return await call_next(request)
+        if not rate_limiter.allow(client_ip(request)):
+            return JSONResponse(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                content={"failure": "Rate limit exceeded"},
+            )
+        return await call_next(request)
 
 
 class ApiKeyMiddleware(BaseHTTPMiddleware):
@@ -71,6 +90,7 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(ApiKeyMiddleware)
+app.add_middleware(RateLimitMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,

--- a/python/src/validation.py
+++ b/python/src/validation.py
@@ -54,6 +54,21 @@ def validate_hex_string(value: str) -> str:
     return value.lower()
 
 
+DEFAULT_MAX_BROADCAST_TX_BYTES = 1_000_000
+
+
+def validate_broadcast_tx_hex(
+    value: str, max_bytes: int = DEFAULT_MAX_BROADCAST_TX_BYTES
+) -> str:
+    value = validate_hex_string(value)
+    tx_bytes = len(value) // 2
+    if tx_bytes > max_bytes:
+        raise ValueError(
+            f"Transaction too large: {tx_bytes} bytes exceeds limit of {max_bytes} bytes"
+        )
+    return value
+
+
 def validate_locking_script_pattern(value: str) -> str:
     if not value or len(value) > 512:
         raise ValueError(

--- a/python/tests/test_rate_limit.py
+++ b/python/tests/test_rate_limit.py
@@ -1,0 +1,37 @@
+from rate_limit import FixedWindowRateLimiter, client_ip
+
+
+class TestFixedWindowRateLimiter:
+    def test_disabled_allows_all(self) -> None:
+        limiter = FixedWindowRateLimiter(0)
+        assert limiter.allow("127.0.0.1")
+        assert limiter.allow("127.0.0.1")
+
+    def test_enforces_limit_per_client(self) -> None:
+        limiter = FixedWindowRateLimiter(2)
+        assert limiter.allow("client-a")
+        assert limiter.allow("client-a")
+        assert not limiter.allow("client-a")
+        assert limiter.allow("client-b")
+
+
+class TestClientIp:
+    def test_uses_forwarded_for(self) -> None:
+        class Client:
+            host = "10.0.0.1"
+
+        class Request:
+            headers = {"x-forwarded-for": "203.0.113.5, 10.0.0.1"}
+            client = Client()
+
+        assert client_ip(Request()) == "203.0.113.5"
+
+    def test_falls_back_to_peer(self) -> None:
+        class Client:
+            host = "127.0.0.1"
+
+        class Request:
+            headers = {}
+            client = Client()
+
+        assert client_ip(Request()) == "127.0.0.1"

--- a/python/tests/test_rest_api_smoke.py
+++ b/python/tests/test_rest_api_smoke.py
@@ -34,3 +34,36 @@ class TestRestApiSmoke:
         response = client.get("/block/height", params={"height": -1})
         assert response.status_code == 422
         assert "failure" in response.json()
+
+    def test_rate_limit_returns_429(self, client: TestClient) -> None:
+        import rest_api
+        from rate_limit import FixedWindowRateLimiter
+
+        original_limit = rest_api.rate_limit_per_minute
+        original_limiter = rest_api.rate_limiter
+        rest_api.rate_limit_per_minute = 1
+        rest_api.rate_limiter = FixedWindowRateLimiter(1)
+        try:
+            assert client.get("/").status_code == 200
+            response = client.get("/")
+            assert response.status_code == 429
+            assert response.json()["failure"] == "Rate limit exceeded"
+        finally:
+            rest_api.rate_limit_per_minute = original_limit
+            rest_api.rate_limiter = original_limiter
+
+    def test_health_exempt_from_rate_limit(self, client: TestClient) -> None:
+        import rest_api
+        from rate_limit import FixedWindowRateLimiter
+
+        original_limit = rest_api.rate_limit_per_minute
+        original_limiter = rest_api.rate_limiter
+        rest_api.rate_limit_per_minute = 1
+        rest_api.rate_limiter = FixedWindowRateLimiter(1)
+        try:
+            with patch.object(rest_api.database, "query", return_value=[(1,)]):
+                assert client.get("/health").status_code == 200
+                assert client.get("/health").status_code == 200
+        finally:
+            rest_api.rate_limit_per_minute = original_limit
+            rest_api.rate_limiter = original_limiter

--- a/python/tests/test_rest_api_smoke.py
+++ b/python/tests/test_rest_api_smoke.py
@@ -34,3 +34,10 @@ class TestRestApiSmoke:
         response = client.get("/block/height", params={"height": -1})
         assert response.status_code == 422
         assert "failure" in response.json()
+
+    def test_oversized_broadcast_tx_returns_422(self, client: TestClient) -> None:
+        import rest_api
+
+        hexstr = "00" * (rest_api.max_broadcast_tx_bytes + 1)
+        response = client.post("/tx/hex", json={"tx": hexstr})
+        assert response.status_code == 422

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -1,9 +1,11 @@
 import pytest
 
 from validation import (
+    DEFAULT_MAX_BROADCAST_TX_BYTES,
     MAX_BLOCK_HEIGHT,
     validate_block_hash,
     validate_block_height,
+    validate_broadcast_tx_hex,
     validate_hex_string,
     validate_locking_script_pattern,
     validate_monitor_name,
@@ -75,6 +77,17 @@ class TestValidateHexString:
     def test_rejects_non_hex(self) -> None:
         with pytest.raises(ValueError, match="non-hexadecimal"):
             validate_hex_string("zz")
+
+
+class TestValidateBroadcastTxHex:
+    def test_accepts_tx_within_limit(self) -> None:
+        hexstr = "00" * DEFAULT_MAX_BROADCAST_TX_BYTES
+        assert validate_broadcast_tx_hex(hexstr) == hexstr
+
+    def test_rejects_tx_over_limit(self) -> None:
+        hexstr = "00" * (DEFAULT_MAX_BROADCAST_TX_BYTES + 1)
+        with pytest.raises(ValueError, match="exceeds limit"):
+            validate_broadcast_tx_hex(hexstr)
 
 
 class TestValidateLockingScriptPattern:

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -54,10 +54,25 @@ pub struct DynamicConfigConfig {
     pub filename: String,
 }
 
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct WebInterfaceConfig {
     #[serde(default)]
     pub api_key: Option<String>,
+    #[serde(default = "default_max_broadcast_tx_bytes")]
+    pub max_broadcast_tx_bytes: usize,
+}
+
+fn default_max_broadcast_tx_bytes() -> usize {
+    1_000_000
+}
+
+impl Default for WebInterfaceConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            max_broadcast_tx_bytes: default_max_broadcast_tx_bytes(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -58,6 +58,8 @@ pub struct DynamicConfigConfig {
 pub struct WebInterfaceConfig {
     #[serde(default)]
     pub api_key: Option<String>,
+    #[serde(default)]
+    pub rate_limit_per_minute: u32,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -5,7 +5,7 @@ use actix_web::{web, App, HttpServer};
 use std::{
     net::{IpAddr, Ipv4Addr},
     panic, process,
-    sync::mpsc,
+    sync::{mpsc, Arc},
     thread, time,
 };
 use tokio::signal;
@@ -16,6 +16,7 @@ mod event_handler;
 mod peer_connection;
 mod peer_event;
 mod peer_thread;
+mod rate_limit;
 mod rest_api;
 mod services;
 mod thread_manager;
@@ -25,6 +26,7 @@ mod uaas;
 use crate::{
     config::get_config,
     peer_event::{PeerEventMessage, PeerEventType},
+    rate_limit::RateLimiter,
     rest_api::{add_monitor, broadcast_tx, delete_monitor, health, version, AppState},
     thread_manager::ThreadManager,
     thread_tracker::ThreadTracker,
@@ -54,9 +56,12 @@ async fn main() {
     // Setup web server data
     let (tx_rest, rx_rest) = mpsc::channel();
 
+    let rate_limiter = Arc::new(RateLimiter::new(config.web_interface.rate_limit_per_minute));
+
     let app_state = AppState {
         msg_from_rest_api: tx_rest,
         api_key: config.web_interface.api_key.clone(),
+        rate_limiter,
     };
     let web_state = web::Data::new(app_state);
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -54,9 +54,13 @@ async fn main() {
     // Setup web server data
     let (tx_rest, rx_rest) = mpsc::channel();
 
+    let max_broadcast_tx_bytes = config.web_interface.max_broadcast_tx_bytes;
+    let payload_limit = max_broadcast_tx_bytes.saturating_mul(2).max(1024);
+
     let app_state = AppState {
         msg_from_rest_api: tx_rest,
         api_key: config.web_interface.api_key.clone(),
+        max_broadcast_tx_bytes,
     };
     let web_state = web::Data::new(app_state);
 
@@ -88,6 +92,7 @@ async fn main() {
     // Start webserver
     let server = HttpServer::new(move || {
         App::new()
+            .app_data(web::PayloadConfig::default().limit(payload_limit))
             .app_data(web_state.clone())
             .service(health)
             .service(broadcast_tx)

--- a/rust/src/rate_limit.rs
+++ b/rust/src/rate_limit.rs
@@ -1,0 +1,86 @@
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+const WINDOW: Duration = Duration::from_secs(60);
+
+pub struct RateLimiter {
+    limit_per_minute: u32,
+    windows: Mutex<HashMap<String, (Instant, u32)>>,
+}
+
+impl RateLimiter {
+    pub fn new(limit_per_minute: u32) -> Self {
+        RateLimiter {
+            limit_per_minute,
+            windows: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn allow(&self, client: &str) -> bool {
+        if self.limit_per_minute == 0 {
+            return true;
+        }
+
+        let mut guard = match self.windows.lock() {
+            Ok(guard) => guard,
+            Err(err) => {
+                log::error!("Rate limiter lock poisoned: {err}");
+                return false;
+            }
+        };
+
+        let now = Instant::now();
+        let entry = guard.entry(client.to_string()).or_insert((now, 0));
+        if now.duration_since(entry.0) >= WINDOW {
+            *entry = (now, 0);
+        }
+        if entry.1 >= self.limit_per_minute {
+            return false;
+        }
+        entry.1 += 1;
+        true
+    }
+}
+
+pub fn client_ip(req: &actix_web::HttpRequest) -> String {
+    if let Some(forwarded) = req
+        .headers()
+        .get("X-Forwarded-For")
+        .and_then(|value| value.to_str().ok())
+    {
+        return forwarded
+            .split(',')
+            .next()
+            .unwrap_or(forwarded)
+            .trim()
+            .to_string();
+    }
+    req.connection_info()
+        .peer_addr()
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RateLimiter;
+
+    #[test]
+    fn disabled_limiter_allows_all() {
+        let limiter = RateLimiter::new(0);
+        assert!(limiter.allow("127.0.0.1"));
+        assert!(limiter.allow("127.0.0.1"));
+    }
+
+    #[test]
+    fn enforces_limit_per_window() {
+        let limiter = RateLimiter::new(2);
+        assert!(limiter.allow("client-a"));
+        assert!(limiter.allow("client-a"));
+        assert!(!limiter.allow("client-a"));
+        assert!(limiter.allow("client-b"));
+    }
+}

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -24,6 +24,11 @@ pub enum RestEventMessage {
 pub struct AppState {
     pub msg_from_rest_api: mpsc::Sender<RestEventMessage>,
     pub api_key: Option<String>,
+    pub max_broadcast_tx_bytes: usize,
+}
+
+fn tx_hex_exceeds_limit(hex_len: usize, max_tx_bytes: usize) -> bool {
+    hex_len / 2 > max_tx_bytes
 }
 
 const API_KEY_HEADER: &str = "X-API-Key";
@@ -86,6 +91,16 @@ async fn broadcast_tx(
 ) -> Result<HttpResponse> {
     if let Some(response) = authorize(&req, &data.api_key) {
         return Ok(response);
+    }
+
+    if tx_hex_exceeds_limit(hexstr.len(), data.max_broadcast_tx_bytes) {
+        return Ok(HttpResponse::Ok().json(BroadcastTxResponse {
+            status: "Failed".to_string(),
+            detail: format!(
+                "Transaction exceeds maximum broadcast size of {} bytes",
+                data.max_broadcast_tx_bytes
+            ),
+        }));
     }
 
     // decode the hexstr to tx
@@ -179,4 +194,24 @@ async fn delete_monitor(
     }
 
     Ok(HttpResponse::Ok().finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tx_hex_exceeds_limit;
+
+    #[test]
+    fn tx_hex_within_limit() {
+        assert!(!tx_hex_exceeds_limit(1_999_998, 1_000_000));
+    }
+
+    #[test]
+    fn tx_hex_at_limit() {
+        assert!(!tx_hex_exceeds_limit(2_000_000, 1_000_000));
+    }
+
+    #[test]
+    fn tx_hex_over_limit() {
+        assert!(tx_hex_exceeds_limit(2_000_002, 1_000_000));
+    }
 }

--- a/rust/src/rest_api.rs
+++ b/rust/src/rest_api.rs
@@ -1,5 +1,5 @@
 use std::io::Cursor;
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 
 use actix_web::{
     delete, get, http::header::ContentType, post, web, HttpRequest, HttpResponse, Responder, Result,
@@ -9,6 +9,7 @@ use serde::Serialize;
 use chain_gang::{messages::Tx, util::Serializable};
 
 use crate::config::CollectionConfig;
+use crate::rate_limit::RateLimiter;
 use crate::uaas::util::decode_hexstr;
 
 // RestEventMessage - used for sending messages from REST API to main event processing loop
@@ -24,9 +25,20 @@ pub enum RestEventMessage {
 pub struct AppState {
     pub msg_from_rest_api: mpsc::Sender<RestEventMessage>,
     pub api_key: Option<String>,
+    pub rate_limiter: Arc<RateLimiter>,
 }
 
 const API_KEY_HEADER: &str = "X-API-Key";
+
+fn rate_limit(req: &HttpRequest, limiter: &RateLimiter) -> Option<HttpResponse> {
+    if limiter.allow(&crate::rate_limit::client_ip(req)) {
+        None
+    } else {
+        Some(HttpResponse::TooManyRequests().json(serde_json::json!({
+            "failure": "Rate limit exceeded",
+        })))
+    }
+}
 
 fn authorize(req: &HttpRequest, api_key: &Option<String>) -> Option<HttpResponse> {
     let expected = api_key.as_ref()?;
@@ -67,7 +79,11 @@ async fn health() -> impl Responder {
 }
 
 #[get("/version")]
-async fn version(_data: web::Data<AppState>) -> impl Responder {
+async fn version(req: HttpRequest, data: web::Data<AppState>) -> impl Responder {
+    if let Some(response) = rate_limit(&req, &data.rate_limiter) {
+        return response;
+    }
+
     log::info!("version");
     let version = env!("CARGO_PKG_VERSION");
     let status = format!("{{\"version\": \"{}\"}}", version);
@@ -84,6 +100,9 @@ async fn broadcast_tx(
     req: HttpRequest,
     data: web::Data<AppState>,
 ) -> Result<HttpResponse> {
+    if let Some(response) = rate_limit(&req, &data.rate_limiter) {
+        return Ok(response);
+    }
     if let Some(response) = authorize(&req, &data.api_key) {
         return Ok(response);
     }
@@ -137,6 +156,9 @@ async fn add_monitor(
     req: HttpRequest,
     data: web::Data<AppState>,
 ) -> Result<impl Responder> {
+    if let Some(response) = rate_limit(&req, &data.rate_limiter) {
+        return Ok(response);
+    }
     if let Some(response) = authorize(&req, &data.api_key) {
         return Ok(response);
     }
@@ -163,6 +185,9 @@ async fn delete_monitor(
     req: HttpRequest,
     data: web::Data<AppState>,
 ) -> Result<impl Responder> {
+    if let Some(response) = rate_limit(&req, &data.rate_limiter) {
+        return Ok(response);
+    }
     if let Some(response) = authorize(&req, &data.api_key) {
         return Ok(response);
     }


### PR DESCRIPTION
## Summary
- Add optional `max_broadcast_tx_bytes` under `[web_interface]` (default 1 MiB decoded tx size)
- Reject oversized broadcasts on Python `POST /tx/hex` and Rust `POST /tx/raw` before parsing
- Set actix payload limit to twice the byte limit so oversized hex bodies fail at the HTTP layer

## Test plan
- [x] `cargo test`
- [x] `uv run pytest python/tests/test_validation.py python/tests/test_rest_api_smoke.py`
- [ ] Broadcast a normal-sized tx and confirm success
- [ ] Send an oversized hex payload and confirm rejection (422 on Python, Failed response on Rust)


Made with [Cursor](https://cursor.com)