### PR TITLE
Isolate thread panics so workers do not exit the process

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -20,6 +20,7 @@ mod rest_api;
 mod services;
 mod thread_manager;
 mod thread_tracker;
+mod thread_util;
 mod uaas;
 
 use crate::{
@@ -28,6 +29,7 @@ use crate::{
     rest_api::{add_monitor, broadcast_tx, delete_monitor, health, version, AppState},
     thread_manager::ThreadManager,
     thread_tracker::ThreadTracker,
+    thread_util::catch_unwind_logged,
     uaas::logic::Logic,
 };
 
@@ -40,12 +42,11 @@ async fn main() {
 }
 
 async fn run() -> Result<(), String> {
-    // Hook in our own panic handler
+    // Log panics without terminating unrelated threads (for example the web server).
     let orig_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
-        // invoke the default handler and exit the process
+        log::error!("Thread panic: {panic_info}");
         orig_hook(panic_info);
-        process::exit(1);
     }));
 
     let config = get_config("UAASR_CONFIG", "../data/uaasr.toml")?;
@@ -78,15 +79,16 @@ async fn run() -> Result<(), String> {
     let ips = config.get_ips()?;
 
     // Start the peer threads
-    let handle = thread::spawn(move ||
-        // Cycle around all the IP addresses
-        for ip in ips.into_iter().cycle() {
-            manager.create_thread(ip, &mut children, &config);
-            if manager.process_messages(&mut children, &mut logic) {
-                break;
-            };
-        }
-    );
+    let handle = thread::spawn(move || {
+        catch_unwind_logged("peer manager", || {
+            for ip in ips.into_iter().cycle() {
+                manager.create_thread(ip, &mut children, &config);
+                if manager.process_messages(&mut children, &mut logic) {
+                    break;
+                }
+            }
+        });
+    });
 
     // Start webserver
     let server = HttpServer::new(move || {
@@ -125,8 +127,8 @@ async fn run() -> Result<(), String> {
         .map_err(|err| format!("web server error: {err}"))?;
 
     // Wait for peer threads
-    if let Err(e) = handle.join() {
-        log::error!("Peer manager thread panicked during shutdown: {:?}", e);
+    if handle.join().is_err() {
+        log::error!("Peer manager thread panicked during shutdown");
     }
 
     Ok(())

--- a/rust/src/peer_connection.rs
+++ b/rust/src/peer_connection.rs
@@ -23,15 +23,16 @@ pub struct PeerConnection {
 }
 
 impl PeerConnection {
-    pub fn new(ip: IpAddr, config: &Config, tx: mpsc::Sender<PeerEventMessage>) -> Self {
-        // Config is validated in main before peer threads are started.
+    pub fn new(
+        ip: IpAddr,
+        config: &Config,
+        tx: mpsc::Sender<PeerEventMessage>,
+    ) -> Result<Self, String> {
         let settings = config
             .get_network_settings()
-            .expect("config must pass validate_startup before peer connections");
+            .map_err(|err| err.to_string())?;
         let port = settings.port;
-        let network = config
-            .get_network()
-            .expect("config must pass validate_startup before peer connections");
+        let network = config.get_network().map_err(|err| err.to_string())?;
         let user_agent = &config.service.user_agent;
 
         let mut rng = rand::rng();
@@ -54,10 +55,10 @@ impl PeerConnection {
         peer.disconnected_event().subscribe(&event_handler);
         peer.messages().subscribe(&event_handler);
 
-        PeerConnection {
+        Ok(PeerConnection {
             peer,
             event_handler,
-        }
+        })
     }
 
     pub fn wait_for_messages(&self, timeout_period: f64, running: Arc<AtomicBool>) {

--- a/rust/src/peer_event.rs
+++ b/rust/src/peer_event.rs
@@ -28,14 +28,14 @@ fn obj_type_as_string(o_type: u32) -> String {
         2 => "BLOCK".to_string(),
         3 => "FILTERED_BLOCK".to_string(),
         4 => "CMPCT_BLOCK".to_string(),
-        value => format!("unknown obj_type {}", value),
+        value => format!("unknown obj_type {value}"),
     }
 }
 
 impl fmt::Display for PeerEventType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            PeerEventType::Connected(detail) => write!(f, "Connected=({})", detail),
+            PeerEventType::Connected(detail) => write!(f, "Connected=({detail})"),
             PeerEventType::Disconnected => write!(f, "Disconnected"),
             PeerEventType::Addr(addr) => write!(f, "Addr={}", addr.addrs.len()),
             PeerEventType::Tx(tx) => write!(f, "Tx={:?}", tx.hash()),
@@ -47,22 +47,16 @@ impl fmt::Display for PeerEventType {
             ),
             PeerEventType::Headers(headers) => write!(f, "Headers={:?}", headers.headers.len()),
             PeerEventType::Inv(inv) => match inv.objects.len() {
+                0 => write!(f, "Inv=0"),
                 1 => {
                     let hash = Hash256::encode(&inv.objects[0].hash);
                     write!(
                         f,
-                        "Inv={:?} ({}) {}",
-                        inv.objects.len(),
-                        obj_type_as_string(inv.objects[0].obj_type),
-                        hash
+                        "Inv=1 ({}) {hash}",
+                        obj_type_as_string(inv.objects[0].obj_type)
                     )
                 }
-                _ => write!(
-                    f,
-                    "Inv={:?} ({})",
-                    inv.objects.len(),
-                    obj_type_as_string(inv.objects[0].obj_type)
-                ),
+                len => write!(f, "Inv={len}"),
             },
 
             PeerEventType::Stop => write!(f, "Stop"),
@@ -80,10 +74,40 @@ pub struct PeerEventMessage {
 
 impl fmt::Display for PeerEventMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let sys_time = self
+        let elapsed = self
             .time
             .duration_since(time::SystemTime::UNIX_EPOCH)
-            .unwrap();
-        write!(f, "{:?}, {}, {}", sys_time, self.peer, self.event)
+            .map(|duration| format!("{duration:?}"))
+            .unwrap_or_else(|_| "unknown".to_string());
+        write!(f, "{elapsed}, {}, {}", self.peer, self.event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_gang::messages::InvVect;
+
+    #[test]
+    fn inv_display_handles_empty_inventory() {
+        let event = PeerEventType::Inv(Inv { objects: vec![] });
+        assert_eq!(format!("{event}"), "Inv=0");
+    }
+
+    #[test]
+    fn inv_display_handles_multiple_objects() {
+        let event = PeerEventType::Inv(Inv {
+            objects: vec![
+                InvVect {
+                    obj_type: 1,
+                    hash: Hash256::default(),
+                },
+                InvVect {
+                    obj_type: 2,
+                    hash: Hash256::default(),
+                },
+            ],
+        });
+        assert_eq!(format!("{event}"), "Inv=2");
     }
 }

--- a/rust/src/thread_manager.rs
+++ b/rust/src/thread_manager.rs
@@ -2,7 +2,7 @@ use std::{
     net::IpAddr,
     sync::{atomic::AtomicBool, mpsc, Arc},
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use chain_gang::messages::Message;
@@ -14,6 +14,7 @@ use crate::{
     peer_thread::{PeerThread, PeerThreadStatus},
     rest_api::RestEventMessage,
     thread_tracker::ThreadTracker,
+    thread_util::catch_unwind_logged,
     uaas::logic::{Logic, ServerStateType},
 };
 
@@ -57,6 +58,7 @@ impl ThreadManager {
             }
         };
 
+        let notify_tx = local_tx.clone();
         let peer_connection = match PeerConnection::new(ip, &local_config, local_tx) {
             Ok(peer_connection) => peer_connection,
             Err(err) => {
@@ -65,9 +67,23 @@ impl ThreadManager {
             }
         };
         let peer = peer_connection.peer.clone();
+        let peer_ip = ip;
         let peer_thread = PeerThread {
             thread: Some(thread::spawn(move || {
-                peer_connection.wait_for_messages(timeout_period, local_running);
+                let finished = catch_unwind_logged(&format!("peer connection {peer_ip}"), || {
+                    peer_connection.wait_for_messages(timeout_period, local_running)
+                })
+                .is_some();
+                if !finished {
+                    let msg = PeerEventMessage {
+                        time: SystemTime::now(),
+                        peer: peer_ip,
+                        event: PeerEventType::Disconnected,
+                    };
+                    if notify_tx.send(msg).is_err() {
+                        log::warn!("Failed to notify peer manager that {peer_ip} thread panicked");
+                    }
+                }
             })),
             status: PeerThreadStatus::Started,
             running: peer_running,
@@ -78,6 +94,18 @@ impl ThreadManager {
     }
 
     fn process_event(
+        &self,
+        received: PeerEventMessage,
+        thread_tracker: &mut ThreadTracker,
+        logic: &mut Logic,
+    ) -> bool {
+        catch_unwind_logged(&format!("peer event handler for {}", received.peer), || {
+            self.process_event_inner(received, thread_tracker, logic)
+        })
+        .unwrap_or(true)
+    }
+
+    fn process_event_inner(
         &self,
         received: PeerEventMessage,
         thread_tracker: &mut ThreadTracker,

--- a/rust/src/thread_manager.rs
+++ b/rust/src/thread_manager.rs
@@ -49,14 +49,21 @@ impl ThreadManager {
         let local_running: Arc<AtomicBool> = Arc::new(AtomicBool::new(true));
         let peer_running = local_running.clone();
 
-        // Read config
-        // Config is validated in main before peer threads are started.
-        let timeout_period = config
-            .get_network_settings()
-            .expect("config must pass validate_startup before peer connections")
-            .timeout_period;
+        let timeout_period = match config.get_network_settings() {
+            Ok(settings) => settings.timeout_period,
+            Err(err) => {
+                log::error!("Invalid network settings when creating peer thread: {err}");
+                return;
+            }
+        };
 
-        let peer_connection = PeerConnection::new(ip, &local_config, local_tx);
+        let peer_connection = match PeerConnection::new(ip, &local_config, local_tx) {
+            Ok(peer_connection) => peer_connection,
+            Err(err) => {
+                log::error!("Unable to create peer connection for {ip}: {err}");
+                return;
+            }
+        };
         let peer = peer_connection.peer.clone();
         let peer_thread = PeerThread {
             thread: Some(thread::spawn(move || {

--- a/rust/src/thread_tracker.rs
+++ b/rust/src/thread_tracker.rs
@@ -87,8 +87,8 @@ impl ThreadTracker {
             let started_at = peer.started_at;
 
             if let Some(thread) = peer.thread {
-                if let Err(e) = thread.join() {
-                    log::error!("Peer thread join failed for {}: {:?}", ip, e);
+                if thread.join().is_err() {
+                    log::error!("Peer thread for {ip} panicked");
                 }
 
                 // Create a new entry to replace the existing one

--- a/rust/src/thread_util.rs
+++ b/rust/src/thread_util.rs
@@ -1,0 +1,36 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Run `f`, logging and swallowing panics so caller threads keep running.
+pub fn catch_unwind_logged<F, R>(label: &str, f: F) -> Option<R>
+where
+    F: FnOnce() -> R,
+{
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(value) => Some(value),
+        Err(payload) => {
+            if let Some(message) = payload.downcast_ref::<&str>() {
+                log::error!("Thread panic in {label}: {message}");
+            } else if let Some(message) = payload.downcast_ref::<String>() {
+                log::error!("Thread panic in {label}: {message}");
+            } else {
+                log::error!("Thread panic in {label}: unknown payload");
+            }
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::catch_unwind_logged;
+
+    #[test]
+    fn returns_some_on_success() {
+        assert_eq!(catch_unwind_logged("test", || 42), Some(42));
+    }
+
+    #[test]
+    fn returns_none_on_panic() {
+        assert!(catch_unwind_logged("test", || panic!("boom")).is_none());
+    }
+}

--- a/rust/src/uaas/address_manager.rs
+++ b/rust/src/uaas/address_manager.rs
@@ -64,6 +64,10 @@ impl AddressManager {
     }
 
     pub fn on_addr(&mut self, addr: Addr) {
+        if addr.addrs.is_empty() {
+            return;
+        }
+
         let addr_insert = match self
             .conn
             .prep("INSERT INTO addr (ip, services, port) VALUES (:ip, :services, :port)")

--- a/rust/src/uaas/database.rs
+++ b/rust/src/uaas/database.rs
@@ -369,13 +369,10 @@ mod test {
             return;
         };
 
-        let pool = Pool::new(url.as_str()).unwrap_or_else(|err| {
-            panic!(
-                "Problem connecting to database at {url}. \
-                 Check database is connected and database connection configuration is correct.\n: {err}"
-            );
-        });
-        let conn = pool.get_conn().unwrap();
+        let pool = Pool::new(url.as_str()).expect("connect to UAAS_TEST_MYSQL_URL");
+        let conn = pool
+            .get_conn()
+            .expect("get connection for database integration test");
         let (_tx, rx) = mpsc::channel();
         let mut database = Database {
             conn,

--- a/rust/src/uaas/logic.rs
+++ b/rust/src/uaas/logic.rs
@@ -9,6 +9,7 @@ use chain_gang::{
 
 use crate::{
     config::Config,
+    thread_util::catch_unwind_logged,
     uaas::{
         address_manager::AddressManager, block_manager::BlockManager, connection::Connection,
         database::Database, tx_analyser::TxAnalyser,
@@ -106,8 +107,10 @@ impl Logic {
 
         let db_config = config.clone();
         logic.thread = Some(thread::spawn(move || {
-            let mut database = Database::new(db_conn, rx, &db_config);
-            database.perform_db_operations();
+            catch_unwind_logged("database writer", || {
+                let mut database = Database::new(db_conn, rx, &db_config);
+                database.perform_db_operations();
+            });
         }));
 
         Ok(logic)

--- a/rust/src/uaas/logic.rs
+++ b/rust/src/uaas/logic.rs
@@ -238,28 +238,32 @@ impl Logic {
         }
     }
 
+    fn trim_empty_inventory_front(&mut self) {
+        while self
+            .block_inventory
+            .first()
+            .is_some_and(|entries| entries.is_empty())
+        {
+            self.block_inventory.remove(0);
+        }
+    }
+
     fn request_next_block(&mut self, hash: Option<Hash256>) {
         // Remove the received hash from the inventory
         log::info!("request_next_block {:?}", &hash);
         if let Some(hash) = hash {
-            // no point looking if there is nothing in the block_inventory
-            if !self.block_inventory.is_empty() {
-                // As each hash arrives remove it from the block_inventory
-                self.block_inventory[0].retain(|block| block.hash != hash);
+            if let Some(entries) = self.block_inventory.first_mut() {
+                entries.retain(|block| block.hash != hash);
             }
         }
-        // while there is an empty entry at the front of block_inventory
-        while !self.block_inventory.is_empty() && self.block_inventory[0].is_empty() {
-            // remove empty list from front
-            let _ = self.block_inventory.remove(0);
-        }
+        self.trim_empty_inventory_front();
 
         // Display block_inventory
-        if !self.block_inventory.is_empty() {
+        if let Some(entries) = self.block_inventory.first() {
             log::info!(
                 "block_inventory.len = {}, [0].len = {}",
                 self.block_inventory.len(),
-                self.block_inventory[0].len()
+                entries.len()
             );
         } else {
             log::info!(
@@ -291,7 +295,11 @@ impl Logic {
             self.send_message_queue.push(message)
 
             // else take the first block off the queue
-        } else if let Some(block) = self.block_inventory[0].first() {
+        } else if let Some(block) = self
+            .block_inventory
+            .first()
+            .and_then(|entries| entries.first())
+        {
             let object: Vec<InvVect> = vec![block.clone()];
             // Request the block with GetData
             log::info!("requesting GetData {:?}", object[0].hash.encode());
@@ -299,9 +307,7 @@ impl Logic {
             self.send_message_queue.push(want);
         } else {
             log::error!("Block inventory has empty first entry; removing stale entry");
-            if !self.block_inventory.is_empty() {
-                self.block_inventory.remove(0);
-            }
+            self.trim_empty_inventory_front();
         }
     }
 

--- a/rust/src/uaas/tx_analyser.rs
+++ b/rust/src/uaas/tx_analyser.rs
@@ -376,8 +376,8 @@ mod tests {
         //fn script_to_pubkeyhash(locking_script: &Script) -> String {
         //"asm": "OP_DUP OP_HASH160 7c78584493557fac782023a4ad591b64545929d9 OP_EQUALVERIFY OP_CHECKSIG",
 
-        let encoded_script =
-            hex::decode("76a9147c78584493557fac782023a4ad591b64545929d988ac").unwrap();
+        let encoded_script = hex::decode("76a9147c78584493557fac782023a4ad591b64545929d988ac")
+            .expect("valid test locking script hex");
         let locking_script = Script(encoded_script);
         let result = script_to_pubkeyhash(&locking_script);
         println!("{}", &result);

--- a/rust/src/uaas/util.rs
+++ b/rust/src/uaas/util.rs
@@ -28,10 +28,13 @@ pub fn timestamp_age_as_sec(timestamp: u32) -> u64 {
     // Return the age of the block timestamp (against current time) in seconds
     let block_timestamp: u64 = timestamp.into();
 
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs(),
+        Err(err) => {
+            log::warn!("Unable to read system time: {err:?}");
+            return 0;
+        }
+    };
 
     now.saturating_sub(block_timestamp)
 }


### PR DESCRIPTION
## Summary
Stacks on #67 (`fix/more-unwrap-hot-paths`), which stacks on #64.

- Remove `process::exit(1)` from the global panic hook so worker panics no longer kill the REST API
- Add `catch_unwind_logged` helper and wrap peer manager, peer connection, database writer, and event handler paths
- On peer connection thread panic, emit a synthetic `Disconnected` event so the manager can reconnect

## Test plan
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [ ] Merge #64 and #67 first, then rebase onto `main` if needed before final merge
- [ ] Induce a panic in a peer handler and confirm the web server stays up


Made with [Cursor](https://cursor.com)