### PR TITLE
Reduce runtime panics in logic and peer hot paths

### DIFF
--- a/rust/src/peer_connection.rs
+++ b/rust/src/peer_connection.rs
@@ -23,15 +23,16 @@ pub struct PeerConnection {
 }
 
 impl PeerConnection {
-    pub fn new(ip: IpAddr, config: &Config, tx: mpsc::Sender<PeerEventMessage>) -> Self {
-        // Config is validated in main before peer threads are started.
+    pub fn new(
+        ip: IpAddr,
+        config: &Config,
+        tx: mpsc::Sender<PeerEventMessage>,
+    ) -> Result<Self, String> {
         let settings = config
             .get_network_settings()
-            .expect("config must pass validate_startup before peer connections");
+            .map_err(|err| err.to_string())?;
         let port = settings.port;
-        let network = config
-            .get_network()
-            .expect("config must pass validate_startup before peer connections");
+        let network = config.get_network().map_err(|err| err.to_string())?;
         let user_agent = &config.service.user_agent;
 
         let mut rng = rand::rng();
@@ -54,10 +55,10 @@ impl PeerConnection {
         peer.disconnected_event().subscribe(&event_handler);
         peer.messages().subscribe(&event_handler);
 
-        PeerConnection {
+        Ok(PeerConnection {
             peer,
             event_handler,
-        }
+        })
     }
 
     pub fn wait_for_messages(&self, timeout_period: f64, running: Arc<AtomicBool>) {

--- a/rust/src/peer_event.rs
+++ b/rust/src/peer_event.rs
@@ -28,14 +28,14 @@ fn obj_type_as_string(o_type: u32) -> String {
         2 => "BLOCK".to_string(),
         3 => "FILTERED_BLOCK".to_string(),
         4 => "CMPCT_BLOCK".to_string(),
-        value => format!("unknown obj_type {}", value),
+        value => format!("unknown obj_type {value}"),
     }
 }
 
 impl fmt::Display for PeerEventType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            PeerEventType::Connected(detail) => write!(f, "Connected=({})", detail),
+            PeerEventType::Connected(detail) => write!(f, "Connected=({detail})"),
             PeerEventType::Disconnected => write!(f, "Disconnected"),
             PeerEventType::Addr(addr) => write!(f, "Addr={}", addr.addrs.len()),
             PeerEventType::Tx(tx) => write!(f, "Tx={:?}", tx.hash()),
@@ -47,22 +47,16 @@ impl fmt::Display for PeerEventType {
             ),
             PeerEventType::Headers(headers) => write!(f, "Headers={:?}", headers.headers.len()),
             PeerEventType::Inv(inv) => match inv.objects.len() {
+                0 => write!(f, "Inv=0"),
                 1 => {
                     let hash = Hash256::encode(&inv.objects[0].hash);
                     write!(
                         f,
-                        "Inv={:?} ({}) {}",
-                        inv.objects.len(),
-                        obj_type_as_string(inv.objects[0].obj_type),
-                        hash
+                        "Inv=1 ({}) {hash}",
+                        obj_type_as_string(inv.objects[0].obj_type)
                     )
                 }
-                _ => write!(
-                    f,
-                    "Inv={:?} ({})",
-                    inv.objects.len(),
-                    obj_type_as_string(inv.objects[0].obj_type)
-                ),
+                len => write!(f, "Inv={len}"),
             },
 
             PeerEventType::Stop => write!(f, "Stop"),
@@ -80,10 +74,40 @@ pub struct PeerEventMessage {
 
 impl fmt::Display for PeerEventMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let sys_time = self
+        let elapsed = self
             .time
             .duration_since(time::SystemTime::UNIX_EPOCH)
-            .unwrap();
-        write!(f, "{:?}, {}, {}", sys_time, self.peer, self.event)
+            .map(|duration| format!("{duration:?}"))
+            .unwrap_or_else(|_| "unknown".to_string());
+        write!(f, "{elapsed}, {}, {}", self.peer, self.event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_gang::messages::InvVect;
+
+    #[test]
+    fn inv_display_handles_empty_inventory() {
+        let event = PeerEventType::Inv(Inv { objects: vec![] });
+        assert_eq!(format!("{event}"), "Inv=0");
+    }
+
+    #[test]
+    fn inv_display_handles_multiple_objects() {
+        let event = PeerEventType::Inv(Inv {
+            objects: vec![
+                InvVect {
+                    obj_type: 1,
+                    hash: Hash256::default(),
+                },
+                InvVect {
+                    obj_type: 2,
+                    hash: Hash256::default(),
+                },
+            ],
+        });
+        assert_eq!(format!("{event}"), "Inv=2");
     }
 }

--- a/rust/src/thread_manager.rs
+++ b/rust/src/thread_manager.rs
@@ -49,14 +49,21 @@ impl ThreadManager {
         let local_running: Arc<AtomicBool> = Arc::new(AtomicBool::new(true));
         let peer_running = local_running.clone();
 
-        // Read config
-        // Config is validated in main before peer threads are started.
-        let timeout_period = config
-            .get_network_settings()
-            .expect("config must pass validate_startup before peer connections")
-            .timeout_period;
+        let timeout_period = match config.get_network_settings() {
+            Ok(settings) => settings.timeout_period,
+            Err(err) => {
+                log::error!("Invalid network settings when creating peer thread: {err}");
+                return;
+            }
+        };
 
-        let peer_connection = PeerConnection::new(ip, &local_config, local_tx);
+        let peer_connection = match PeerConnection::new(ip, &local_config, local_tx) {
+            Ok(peer_connection) => peer_connection,
+            Err(err) => {
+                log::error!("Unable to create peer connection for {ip}: {err}");
+                return;
+            }
+        };
         let peer = peer_connection.peer.clone();
         let peer_thread = PeerThread {
             thread: Some(thread::spawn(move || {

--- a/rust/src/uaas/address_manager.rs
+++ b/rust/src/uaas/address_manager.rs
@@ -64,6 +64,10 @@ impl AddressManager {
     }
 
     pub fn on_addr(&mut self, addr: Addr) {
+        if addr.addrs.is_empty() {
+            return;
+        }
+
         let addr_insert = match self
             .conn
             .prep("INSERT INTO addr (ip, services, port) VALUES (:ip, :services, :port)")

--- a/rust/src/uaas/database.rs
+++ b/rust/src/uaas/database.rs
@@ -369,13 +369,10 @@ mod test {
             return;
         };
 
-        let pool = Pool::new(url.as_str()).unwrap_or_else(|err| {
-            panic!(
-                "Problem connecting to database at {url}. \
-                 Check database is connected and database connection configuration is correct.\n: {err}"
-            );
-        });
-        let conn = pool.get_conn().unwrap();
+        let pool = Pool::new(url.as_str()).expect("connect to UAAS_TEST_MYSQL_URL");
+        let conn = pool
+            .get_conn()
+            .expect("get connection for database integration test");
         let (_tx, rx) = mpsc::channel();
         let mut database = Database {
             conn,

--- a/rust/src/uaas/logic.rs
+++ b/rust/src/uaas/logic.rs
@@ -238,28 +238,32 @@ impl Logic {
         }
     }
 
+    fn trim_empty_inventory_front(&mut self) {
+        while self
+            .block_inventory
+            .first()
+            .is_some_and(|entries| entries.is_empty())
+        {
+            self.block_inventory.remove(0);
+        }
+    }
+
     fn request_next_block(&mut self, hash: Option<Hash256>) {
         // Remove the received hash from the inventory
         log::info!("request_next_block {:?}", &hash);
         if let Some(hash) = hash {
-            // no point looking if there is nothing in the block_inventory
-            if !self.block_inventory.is_empty() {
-                // As each hash arrives remove it from the block_inventory
-                self.block_inventory[0].retain(|block| block.hash != hash);
+            if let Some(entries) = self.block_inventory.first_mut() {
+                entries.retain(|block| block.hash != hash);
             }
         }
-        // while there is an empty entry at the front of block_inventory
-        while !self.block_inventory.is_empty() && self.block_inventory[0].is_empty() {
-            // remove empty list from front
-            let _ = self.block_inventory.remove(0);
-        }
+        self.trim_empty_inventory_front();
 
         // Display block_inventory
-        if !self.block_inventory.is_empty() {
+        if let Some(entries) = self.block_inventory.first() {
             log::info!(
                 "block_inventory.len = {}, [0].len = {}",
                 self.block_inventory.len(),
-                self.block_inventory[0].len()
+                entries.len()
             );
         } else {
             log::info!(
@@ -291,7 +295,11 @@ impl Logic {
             self.send_message_queue.push(message)
 
             // else take the first block off the queue
-        } else if let Some(block) = self.block_inventory[0].first() {
+        } else if let Some(block) = self
+            .block_inventory
+            .first()
+            .and_then(|entries| entries.first())
+        {
             let object: Vec<InvVect> = vec![block.clone()];
             // Request the block with GetData
             log::info!("requesting GetData {:?}", object[0].hash.encode());
@@ -299,9 +307,7 @@ impl Logic {
             self.send_message_queue.push(want);
         } else {
             log::error!("Block inventory has empty first entry; removing stale entry");
-            if !self.block_inventory.is_empty() {
-                self.block_inventory.remove(0);
-            }
+            self.trim_empty_inventory_front();
         }
     }
 

--- a/rust/src/uaas/tx_analyser.rs
+++ b/rust/src/uaas/tx_analyser.rs
@@ -376,8 +376,8 @@ mod tests {
         //fn script_to_pubkeyhash(locking_script: &Script) -> String {
         //"asm": "OP_DUP OP_HASH160 7c78584493557fac782023a4ad591b64545929d9 OP_EQUALVERIFY OP_CHECKSIG",
 
-        let encoded_script =
-            hex::decode("76a9147c78584493557fac782023a4ad591b64545929d988ac").unwrap();
+        let encoded_script = hex::decode("76a9147c78584493557fac782023a4ad591b64545929d988ac")
+            .expect("valid test locking script hex");
         let locking_script = Script(encoded_script);
         let result = script_to_pubkeyhash(&locking_script);
         println!("{}", &result);

--- a/rust/src/uaas/util.rs
+++ b/rust/src/uaas/util.rs
@@ -28,10 +28,13 @@ pub fn timestamp_age_as_sec(timestamp: u32) -> u64 {
     // Return the age of the block timestamp (against current time) in seconds
     let block_timestamp: u64 = timestamp.into();
 
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs(),
+        Err(err) => {
+            log::warn!("Unable to read system time: {err:?}");
+            return 0;
+        }
+    };
 
     now.saturating_sub(block_timestamp)
 }


### PR DESCRIPTION
## Summary
Lands #67 changes on `main` after the stacked merge into `fix/startup-unwrap-reduction`.

- Safe block inventory access in `logic.rs`
- `Result`-based `PeerConnection::new`
- Non-panicking peer event formatting and util timestamps


Made with [Cursor](https://cursor.com)