### PR TITLE
Add database performance indexes and mempool primary key

### DIFF
--- a/init_database/03_performance_indexes.sql
+++ b/init_database/03_performance_indexes.sql
@@ -1,0 +1,18 @@
+-- Performance indexes for height-based queries and mempool lookups.
+-- Safe to run on existing databases; Rust startup also applies these via schema.rs.
+-- Replace `main_uaas_db` with your database name if different.
+
+USE main_uaas_db;
+
+CREATE INDEX IF NOT EXISTS idx_blocks_height ON blocks (height);
+CREATE INDEX IF NOT EXISTS idx_tx_height_blockindex ON tx (height, blockindex);
+CREATE INDEX IF NOT EXISTS idx_utxo_height ON utxo (height);
+
+-- Migrate legacy mempool tables that only had idx_txkey on hash.
+DELETE m1 FROM mempool m1
+INNER JOIN mempool m2 ON m1.hash = m2.hash AND m1.time > m2.time;
+
+DROP INDEX IF EXISTS idx_txkey ON mempool;
+
+-- Ignore error 1068 (multiple primary key) if already migrated.
+ALTER TABLE mempool ADD PRIMARY KEY (hash);

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -172,7 +172,8 @@ def init_integration_schema(mysql_url: str) -> None:
                 `offset` bigint unsigned not null,
                 blocksize int unsigned not null,
                 numtxs int unsigned not null,
-                PRIMARY KEY (hash)
+                PRIMARY KEY (hash),
+                INDEX idx_blocks_height (height)
             )
             """
         )
@@ -184,7 +185,8 @@ def init_integration_schema(mysql_url: str) -> None:
                 blockindex int unsigned not null,
                 txsize int unsigned not null,
                 satoshis bigint unsigned not null,
-                PRIMARY KEY (hash)
+                PRIMARY KEY (hash),
+                INDEX idx_tx_height_blockindex (height, blockindex)
             )
             """
         )
@@ -196,7 +198,9 @@ def init_integration_schema(mysql_url: str) -> None:
                 satoshis bigint unsigned not null,
                 height int not null,
                 pubkeyhash varchar(64),
-                PRIMARY KEY (hash, pos)
+                PRIMARY KEY (hash, pos),
+                INDEX speed_key (pubkeyhash),
+                INDEX idx_utxo_height (height)
             )
             """
         )
@@ -207,7 +211,8 @@ def init_integration_schema(mysql_url: str) -> None:
                 locktime int unsigned not null,
                 fee bigint unsigned not null,
                 time int unsigned not null,
-                tx longtext not null
+                tx longtext not null,
+                PRIMARY KEY (hash)
             )
             """
         )

--- a/rust/src/uaas/block_manager.rs
+++ b/rust/src/uaas/block_manager.rs
@@ -153,9 +153,9 @@ impl BlockManager {
             }
             if let Err(err) = self
                 .conn
-                .query_drop(r"CREATE INDEX idx_hash ON blocks (hash);")
+                .query_drop(r"CREATE INDEX IF NOT EXISTS idx_blocks_height ON blocks (height);")
             {
-                log::error!("Unable to create blocks hash index: {err:?}");
+                log::error!("Unable to create blocks height index: {err:?}");
             }
         }
 
@@ -457,6 +457,7 @@ impl BlockManager {
     pub fn setup(&mut self, tx_analyser: &mut TxAnalyser) {
         // Does all the startup stuff a BlockManager needs to do
         self.create_tables();
+        super::schema::ensure_performance_indexes(&mut self.conn);
         if self.startup_load_from_database {
             self.load_blockheaders_from_database();
             // Set the status - note that the height is updated by the load_blockheaders_from_database method

--- a/rust/src/uaas/mod.rs
+++ b/rust/src/uaas/mod.rs
@@ -5,6 +5,7 @@ mod connection;
 mod database;
 mod hexslice;
 pub mod logic;
+mod schema;
 mod tx_analyser;
 mod txdb;
 pub mod util;

--- a/rust/src/uaas/schema.rs
+++ b/rust/src/uaas/schema.rs
@@ -1,0 +1,174 @@
+use mysql::{prelude::*, PooledConn};
+
+fn table_exists(conn: &mut PooledConn, table: &str) -> bool {
+    let query = format!(
+        "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES \
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '{table}'"
+    );
+    conn.query_first::<i64, _>(&query)
+        .ok()
+        .flatten()
+        .unwrap_or(0)
+        > 0
+}
+
+fn ensure_index(conn: &mut PooledConn, table: &str, ddl: &str) {
+    if !table_exists(conn, table) {
+        return;
+    }
+    if let Err(err) = conn.query_drop(ddl) {
+        log::warn!("Unable to ensure index on {table}: {err:?}");
+    }
+}
+
+fn ensure_mempool_primary_key(conn: &mut PooledConn) {
+    if !table_exists(conn, "mempool") {
+        return;
+    }
+
+    let has_pk = conn
+        .query_first::<i64, _>(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS \
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'mempool' \
+             AND CONSTRAINT_TYPE = 'PRIMARY KEY'",
+        )
+        .ok()
+        .flatten()
+        .unwrap_or(0)
+        > 0;
+
+    if has_pk {
+        return;
+    }
+
+    log::info!("Migrating mempool table: adding primary key on hash");
+
+    if let Err(err) = conn.query_drop(
+        "DELETE m1 FROM mempool m1 \
+         INNER JOIN mempool m2 ON m1.hash = m2.hash AND m1.time > m2.time",
+    ) {
+        log::warn!("Unable to deduplicate mempool rows before primary key migration: {err:?}");
+    }
+
+    if let Err(err) = conn.query_drop("DROP INDEX IF EXISTS idx_txkey ON mempool") {
+        log::warn!("Unable to drop legacy mempool hash index: {err:?}");
+    }
+
+    if let Err(err) = conn.query_drop("ALTER TABLE mempool ADD PRIMARY KEY (hash)") {
+        log::error!("Unable to add mempool primary key: {err:?}");
+    }
+}
+
+/// Apply height indexes and mempool primary key for existing and new databases.
+pub fn ensure_performance_indexes(conn: &mut PooledConn) {
+    ensure_index(
+        conn,
+        "blocks",
+        "CREATE INDEX IF NOT EXISTS idx_blocks_height ON blocks (height)",
+    );
+    ensure_index(
+        conn,
+        "tx",
+        "CREATE INDEX IF NOT EXISTS idx_tx_height_blockindex ON tx (height, blockindex)",
+    );
+    ensure_index(
+        conn,
+        "utxo",
+        "CREATE INDEX IF NOT EXISTS idx_utxo_height ON utxo (height)",
+    );
+    ensure_mempool_primary_key(conn);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn perf_indexes_apply_on_test_database() {
+        let Some(url) = std::env::var("UAAS_TEST_MYSQL_URL").ok() else {
+            eprintln!("skipping perf_indexes_apply_on_test_database: UAAS_TEST_MYSQL_URL not set");
+            return;
+        };
+
+        let pool = mysql::Pool::new(url.as_str()).expect("connect to UAAS_TEST_MYSQL_URL");
+        let mut conn = pool
+            .get_conn()
+            .expect("get connection for schema migration test");
+
+        conn.query_drop(
+            "CREATE TABLE IF NOT EXISTS blocks (
+                height int unsigned not null,
+                hash varchar(64) not null,
+                version int unsigned not null,
+                prev_hash varchar(64) not null,
+                merkle_root varchar(64) not null,
+                timestamp int unsigned not null,
+                bits int unsigned not null,
+                nonce int unsigned not null,
+                `offset` bigint unsigned not null,
+                blocksize int unsigned not null,
+                numtxs int unsigned not null,
+                PRIMARY KEY (hash)
+            )",
+        )
+        .expect("create blocks table for schema test");
+
+        conn.query_drop(
+            "CREATE TABLE IF NOT EXISTS tx (
+                hash varchar(64) not null,
+                height int unsigned not null,
+                blockindex int unsigned not null,
+                txsize int unsigned not null,
+                satoshis bigint unsigned not null,
+                PRIMARY KEY (hash)
+            )",
+        )
+        .expect("create tx table for schema test");
+
+        conn.query_drop(
+            "CREATE TABLE IF NOT EXISTS utxo (
+                hash varchar(64) not null,
+                pos int unsigned not null,
+                satoshis bigint unsigned not null,
+                height int not null,
+                pubkeyhash varchar(64),
+                PRIMARY KEY (hash, pos)
+            )",
+        )
+        .expect("create utxo table for schema test");
+
+        conn.query_drop("DROP TABLE IF EXISTS mempool")
+            .expect("drop mempool");
+        conn.query_drop(
+            "CREATE TABLE mempool (
+                hash varchar(64) not null,
+                locktime int unsigned not null,
+                fee bigint unsigned not null,
+                time int unsigned not null,
+                tx longtext not null
+            )",
+        )
+        .expect("create legacy mempool table for schema test");
+        conn.query_drop("CREATE INDEX idx_txkey ON mempool (hash)")
+            .expect("create legacy mempool index");
+
+        ensure_performance_indexes(&mut conn);
+
+        let indexes: Vec<String> = conn
+            .query(
+                "SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS \
+                 WHERE TABLE_SCHEMA = DATABASE() \
+                 AND INDEX_NAME IN ('idx_blocks_height', 'idx_tx_height_blockindex', 'idx_utxo_height', 'PRIMARY') \
+                 AND TABLE_NAME IN ('blocks', 'tx', 'utxo', 'mempool')",
+            )
+            .expect("query performance indexes");
+
+        assert!(
+            indexes.len() >= 4,
+            "expected performance indexes to be present, found {indexes:?}"
+        );
+
+        conn.query_drop("DROP TABLE IF EXISTS mempool")
+            .expect("cleanup mempool");
+    }
+}

--- a/rust/src/uaas/txdb.rs
+++ b/rust/src/uaas/txdb.rs
@@ -90,8 +90,10 @@ impl TxDB {
             return;
         }
 
-        if let Err(err) = self.conn.query_drop(r"CREATE INDEX idx_tx ON tx (hash);") {
-            log::error!("Unable to create tx hash index: {err:?}");
+        if let Err(err) = self.conn.query_drop(
+            r"CREATE INDEX IF NOT EXISTS idx_tx_height_blockindex ON tx (height, blockindex);",
+        ) {
+            log::error!("Unable to create tx height index: {err:?}");
         }
     }
 
@@ -103,19 +105,12 @@ impl TxDB {
                 locktime int unsigned not null,
                 fee bigint unsigned not null,
                 time int unsigned not null,
-                tx longtext not null)",
+                tx longtext not null,
+                CONSTRAINT PK_Mempool PRIMARY KEY (hash))",
         ) {
             log::error!("Unable to create mempool table: {err:?}");
-            return;
         }
         // Note that tx longtext should be good for 4GB txs
-
-        if let Err(err) = self
-            .conn
-            .query_drop(r"CREATE INDEX idx_txkey ON mempool (hash);")
-        {
-            log::error!("Unable to create mempool hash index: {err:?}");
-        }
     }
 
     pub fn load_tx(&mut self) {

--- a/rust/src/uaas/utxo.rs
+++ b/rust/src/uaas/utxo.rs
@@ -85,9 +85,16 @@ impl Utxo {
 
         if let Err(err) = self
             .conn
-            .query_drop(r"CREATE INDEX speed_key ON utxo (pubkeyhash);")
+            .query_drop(r"CREATE INDEX IF NOT EXISTS speed_key ON utxo (pubkeyhash);")
         {
             log::error!("Unable to create utxo pubkeyhash index: {err:?}");
+        }
+
+        if let Err(err) = self
+            .conn
+            .query_drop(r"CREATE INDEX IF NOT EXISTS idx_utxo_height ON utxo (height);")
+        {
+            log::error!("Unable to create utxo height index: {err:?}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Add height indexes on `blocks`, `tx`, and `utxo` to speed joins, reorg deletes, and merkle proof queries.
- Give `mempool` a primary key on `hash` (replacing the legacy non-unique index).
- Apply migrations automatically at Rust startup via `schema.rs`, with a manual SQL script for existing deployments.

## Test plan
- [x] `cd rust && cargo clippy && cargo test` (includes `perf_indexes_apply_on_test_database` when `UAAS_TEST_MYSQL_URL` is set)
- [x] `uv run pytest python/tests --ignore=python/tests/integration`
- [ ] CI Python/Rust/Docker jobs
- [ ] Restart Rust service against an existing DB and confirm indexes appear in `INFORMATION_SCHEMA.STATISTICS`


Made with [Cursor](https://cursor.com)