### PR TITLE
Skip commit on read-only Python database queries

### DIFF
--- a/python/src/database.py
+++ b/python/src/database.py
@@ -4,6 +4,28 @@ from mysql.connector.pooling import MySQLConnectionPool
 
 from config import ConfigType
 
+_WRITE_PREFIXES = (
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "REPLACE",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "TRUNCATE",
+    "GRANT",
+    "REVOKE",
+)
+
+
+def _requires_commit(query_string: str) -> bool:
+    """Return True when the statement mutates database state."""
+    normalized = query_string.lstrip()
+    if not normalized:
+        return False
+    first_token = normalized.split(None, 1)[0].upper()
+    return first_token in _WRITE_PREFIXES
+
 
 class Database:
     def __init__(self):
@@ -40,7 +62,8 @@ class Database:
             try:
                 cursor.execute(query_string, params or ())
                 retval = list(cursor.fetchall())
-                connection.commit()
+                if _requires_commit(query_string):
+                    connection.commit()
                 return retval
             finally:
                 cursor.close()

--- a/python/tests/test_database.py
+++ b/python/tests/test_database.py
@@ -1,0 +1,13 @@
+from database import _requires_commit
+
+
+class TestRequiresCommit:
+    def test_select_does_not_require_commit(self) -> None:
+        assert _requires_commit("SELECT 1") is False
+        assert _requires_commit("  select * from utxo") is False
+
+    def test_write_statements_require_commit(self) -> None:
+        assert _requires_commit("INSERT INTO tx VALUES (%s)") is True
+        assert _requires_commit("UPDATE utxo SET satoshis = 1") is True
+        assert _requires_commit("DELETE FROM mempool WHERE hash = %s") is True
+        assert _requires_commit("REPLACE INTO utxo VALUES (%s, %s)") is True


### PR DESCRIPTION
## Summary
- Only call `connection.commit()` for write statements in the Python `Database.query()` helper.
- Read-only REST paths (`SELECT` for UTXO, blocks, tx proof, health, etc.) no longer commit after every query.

## Test plan
- [x] `uv run pytest python/tests/test_database.py`
- [x] `uv run pytest python/tests --ignore=python/tests/integration`
- [ ] CI Python job


Made with [Cursor](https://cursor.com)