### PR TITLE
Consolidate tx_exist checks into a single database query

### DIFF
--- a/python/src/tx_analyser.py
+++ b/python/src/tx_analyser.py
@@ -9,6 +9,25 @@ from config import ConfigType
 from mysql.connector.errors import ProgrammingError
 
 
+_TX_EXIST_QUERY = """
+SELECT 1 FROM (
+    SELECT hash FROM tx WHERE hash = %s
+    UNION ALL
+    SELECT hash FROM mempool WHERE hash = %s
+    UNION ALL
+    SELECT hash FROM collection WHERE hash = %s
+) AS matches LIMIT 1
+"""
+
+_TX_EXIST_WITHOUT_TX_TABLE_QUERY = """
+SELECT 1 FROM (
+    SELECT hash FROM mempool WHERE hash = %s
+    UNION ALL
+    SELECT hash FROM collection WHERE hash = %s
+) AS matches LIMIT 1
+"""
+
+
 class TxAnalyser:
     def __init__(self):
         self.complete = 6
@@ -172,22 +191,13 @@ class TxAnalyser:
         }
 
     def tx_exist(self, hash: str) -> bool:
-        # Return true if txid is in txs or mempool or collection
-        # self.txs.contains_key(&hash) || self.mempool.contains_key(&hash)
+        # Return true if txid is in txs, mempool, or collection (single round trip).
         try:
-            txs = database.query("SELECT * FROM tx WHERE hash = %s;", (hash,))
+            result = database.query(_TX_EXIST_QUERY, (hash, hash, hash))
         except ProgrammingError as e:
             print(f"MySQL ProgrammingError {e}")
-        else:
-            if len(txs) > 0:
-                return True
-        mempool = database.query("SELECT * FROM mempool WHERE hash = %s;", (hash,))
-        if len(mempool) > 0:
-            return True
-        collection = database.query("SELECT * FROM collection WHERE hash = %s;", (hash,))
-        if len(collection) > 0:
-            return True
-        return False
+            result = database.query(_TX_EXIST_WITHOUT_TX_TABLE_QUERY, (hash, hash))
+        return len(result) > 0
 
     def get_tx_merkle_proof(self, hash: str) -> Dict[str, Any]:
         # Given the txid return the merkle branch proof for a confirmed transaction

--- a/python/tests/test_tx_analyser.py
+++ b/python/tests/test_tx_analyser.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from mysql.connector.errors import ProgrammingError
+
+from tx_analyser import (
+    _TX_EXIST_QUERY,
+    _TX_EXIST_WITHOUT_TX_TABLE_QUERY,
+    tx_analyser,
+)
+
+
+VALID_HASH = "a" * 64
+
+
+class TestTxExist:
+    def test_tx_exist_uses_single_query_when_tx_table_available(self) -> None:
+        with patch("tx_analyser.database.query", return_value=[(1,)]) as query:
+            assert tx_analyser.tx_exist(VALID_HASH) is True
+        query.assert_called_once_with(_TX_EXIST_QUERY, (VALID_HASH, VALID_HASH, VALID_HASH))
+
+    def test_tx_exist_returns_false_when_not_found(self) -> None:
+        with patch("tx_analyser.database.query", return_value=[]):
+            assert tx_analyser.tx_exist(VALID_HASH) is False
+
+    def test_tx_exist_falls_back_when_tx_table_missing(self) -> None:
+        with patch("tx_analyser.database.query") as query:
+            query.side_effect = [
+                ProgrammingError("Table 'main_uaas_db.tx' doesn't exist"),
+                [(1,)],
+            ]
+            assert tx_analyser.tx_exist(VALID_HASH) is True
+        assert query.call_count == 2
+        query.assert_any_call(_TX_EXIST_QUERY, (VALID_HASH, VALID_HASH, VALID_HASH))
+        query.assert_any_call(
+            _TX_EXIST_WITHOUT_TX_TABLE_QUERY,
+            (VALID_HASH, VALID_HASH),
+        )


### PR DESCRIPTION
## Summary
- Replace three sequential SELECTs in `tx_analyser.tx_exist()` with one `UNION ALL` query across `tx`, `mempool`, and `collection`.
- Fall back to a two-table query when the `tx` table is unavailable (`save_txs = false`).

## Test plan
- [x] `uv run pytest python/tests/test_tx_analyser.py`
- [x] `uv run pytest python/tests --ignore=python/tests/integration`
- [ ] CI Python job


Made with [Cursor](https://cursor.com)