### PR TITLE
Add MariaDB InnoDB tuning for Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     volumes:
         - ./data/mysql:/var/lib/mysql
         - ./init_database:/docker-entrypoint-initdb.d/:ro
+        - ./docker/mariadb/99-uaas.cnf:/etc/mysql/mariadb.conf.d/99-uaas.cnf:ro
 
   # Basic GUI for interacting with database
   adminer:

--- a/docker/mariadb/99-uaas.cnf
+++ b/docker/mariadb/99-uaas.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+# UaaS indexer tuning for Docker Compose (MariaDB 11.4).
+# On dedicated production hosts, raise innodb_buffer_pool_size to 50–70% of RAM.
+
+innodb_buffer_pool_size = 512M
+innodb_log_buffer_size = 64M
+innodb_flush_log_at_trx_commit = 2
+innodb_io_capacity = 2000
+innodb_io_capacity_max = 4000
+
+max_connections = 100

--- a/docs/Database.md
+++ b/docs/Database.md
@@ -124,6 +124,18 @@ To start the MySQL database in the docker container:
 docker start my-sql
 ```
 
+## Docker Compose MariaDB tuning
+
+`docker-compose up` mounts `docker/mariadb/99-uaas.cnf` into the MariaDB container. It sets InnoDB options tuned for UaaS sync and REST workloads:
+
+* `innodb_buffer_pool_size = 512M` — increase on dedicated hosts (typically 50–70% of RAM)
+* `innodb_flush_log_at_trx_commit = 2` — faster writes with a small durability trade-off (appropriate for an indexer)
+* `innodb_io_capacity` — raised for SSD-backed storage
+
+Store `./data/mysql` on local SSD rather than network storage when possible.
+
+For production, consider also raising `innodb_log_file_size` (requires a fresh datadir or removing `ib_logfile*` while MariaDB is stopped).
+
 # MySQL Workbench (Optional)
 MySQL Workbench provides a simple GUI for browsing the database.
 

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+MARIADB_CNF = REPO_ROOT / "docker" / "mariadb" / "99-uaas.cnf"
+
+
+class TestDeploymentRequirements:
+    def test_compose_mounts_mariadb_innodb_tuning(self) -> None:
+        content = COMPOSE_FILE.read_text(encoding="utf-8")
+        assert "docker/mariadb/99-uaas.cnf" in content
+        assert MARIADB_CNF.is_file()
+
+    def test_mariadb_cnf_sets_innodb_buffer_pool(self) -> None:
+        content = MARIADB_CNF.read_text(encoding="utf-8")
+        assert "innodb_buffer_pool_size" in content
+        assert "innodb_flush_log_at_trx_commit = 2" in content


### PR DESCRIPTION
## Summary
- Mount `docker/mariadb/99-uaas.cnf` in the Compose MariaDB service with InnoDB settings tuned for UaaS sync and REST workloads.
- Document buffer pool sizing, durability trade-offs, and SSD storage guidance in `docs/Database.md`.

## Settings
- `innodb_buffer_pool_size = 512M` (raise on dedicated production hosts)
- `innodb_flush_log_at_trx_commit = 2`
- Raised `innodb_io_capacity` for SSD-backed storage

## Test plan
- [x] `uv run pytest python/tests/test_deployment.py`
- [ ] Restart `docker-compose up -d database` and confirm MariaDB starts with the mounted config
- [ ] CI Python/Rust/Docker jobs


Made with [Cursor](https://cursor.com)