### PR TITLE
Review hardening: logging, security defaults, secret scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env and set real values. .env is gitignored and must not be committed.
+#
+# Docker Compose reads this automatically. Override the MariaDB root password
+# used by the database container:
+MARIADB_ROOT_PASSWORD=change-me-to-a-long-random-secret
+
+# NOTE: the application database users ("uaas" / "maas") and their passwords are
+# currently defined in two places that must stay in sync:
+#   - init_database/01_init.sql / 02_ensure_grants.sql  (user creation + grants)
+#   - data/uaasr.docker.toml                            (connection string used by the app)
+# Fully externalising those into this .env requires templating both files at
+# deploy time (e.g. with envsubst) and a full stack test. Until that is done,
+# rotate those passwords in both files together and never reuse the defaults in
+# any shared or production deployment.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,14 @@ python/data
 
 out.txt
 .vscode
+
+# Secrets / local environment
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+
+# macOS
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
     networks:
       - uaas_network
     environment:
-        MARIADB_ROOT_PASSWORD: mysql
+        # Sourced from a local .env file (see .env.example); falls back to the
+        # historical default so existing dev setups keep working.
+        MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:-mysql}
         MARIADB_DATABASE: db
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]

--- a/python/src/block_manager.py
+++ b/python/src/block_manager.py
@@ -1,9 +1,12 @@
 from typing import List, Dict, Any, Optional
+import logging
 import time
 from database import database
 from p2p_framework.object import CBlockHeader
 import datetime
 from mysql.connector.errors import ProgrammingError
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BlockManager:
@@ -94,7 +97,7 @@ class BlockManager:
             )
             return [x[0] for x in result]
         except ProgrammingError as e:
-            print(f"MySQL ProgrammingError {e}")
+            LOGGER.error("MySQL ProgrammingError: %s", e)
             return []
 
     def _read_last_block(self) -> None | Dict[str, Any]:

--- a/python/src/collection.py
+++ b/python/src/collection.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, Any, List
 from pydantic import BaseModel, field_validator
 import toml
@@ -14,6 +15,8 @@ from database import database
 from tx_analyser import tx_analyser
 from config import ConfigType
 
+LOGGER = logging.getLogger(__name__)
+
 
 def hexstr_to_tx(hash: str, hexstr: str) -> Dict[str, Any]:
     bytes = bytearray.fromhex(hexstr)
@@ -22,7 +25,7 @@ def hexstr_to_tx(hash: str, hexstr: str) -> Dict[str, Any]:
     transaction.rehash()
     # Decode tx
     decode = tx_analyser.decode_tx(hash, transaction)
-    print("decode = ", decode)
+    LOGGER.debug("decode = %s", decode)
     return decode
 
 
@@ -55,7 +58,7 @@ def load_dynamic_config(config: ConfigType) -> List[str]:
         with open(filename, "r") as f:
             config = toml.load(f)
     except FileNotFoundError as e:
-        print(f"load_config - File not found error {e}")
+        LOGGER.warning("load_dynamic_config - file not found: %s", e)
         return []
     else:
         # Read in name fields
@@ -90,19 +93,23 @@ class Collection:
 
     def get_collection_contents(self, monitor_name: str) -> List[Any]:
         """ Return the collection hashes associated with this collection name """
-        assert self.is_valid_collection(monitor_name)
+        if not self.is_valid_collection(monitor_name):
+            raise ValueError(f"Unknown collection '{monitor_name}'")
         return database.query(
             "SELECT hash FROM collection WHERE name = %s;",
             (monitor_name,),
         )
 
     def add_monitor(self, monitor: Monitor):
-        assert not self.is_valid_collection(monitor.name)
+        if self.is_valid_collection(monitor.name):
+            raise ValueError(f"Collection '{monitor.name}' already exists")
         self.dynamic_names.append(monitor.name)
 
     def delete_monitor(self, monitor_name: str):
-        assert self.is_valid_collection(monitor_name)
-        assert self.is_valid_dynamic_collection(monitor_name)
+        if not self.is_valid_collection(monitor_name):
+            raise ValueError(f"Unknown collection '{monitor_name}'")
+        if not self.is_valid_dynamic_collection(monitor_name):
+            raise ValueError(f"Collection '{monitor_name}' is not a dynamic monitor")
         self.dynamic_names.remove(monitor_name)
 
     def is_valid_dynamic_collection(self, monitor_name: str) -> bool:

--- a/python/src/logic.py
+++ b/python/src/logic.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, Any
 
 import requests
@@ -7,6 +8,7 @@ from config import ConfigType
 from mysql.connector.errors import ProgrammingError
 
 RUST_REQUEST_TIMEOUT = 30  # seconds
+LOGGER = logging.getLogger(__name__)
 
 
 class Logic:
@@ -24,7 +26,7 @@ class Logic:
             result = database.query(provided_query)
             return result[0][0]
         except ProgrammingError as e:
-            print(f"MySQL ProgrammingError {e}")
+            LOGGER.error("MySQL ProgrammingError: %s", e)
             return 0
 
     def _get_version(self) -> str:
@@ -32,9 +34,9 @@ class Logic:
         try:
             result = requests.get(url, timeout=RUST_REQUEST_TIMEOUT)
         except requests.exceptions.Timeout:
-            print(f"timeout requesting version from {url}")
+            LOGGER.warning("Timeout requesting version from %s", url)
         except requests.exceptions.ConnectionError as e:
-            print(f"failure = {str(e)}, url = {url}")
+            LOGGER.warning("Unable to connect to %s: %s", url, e)
         else:
             if result.status_code == 200:
                 return result.json()["version"]

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -102,8 +102,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,
     allow_credentials=cors_allow_credentials,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", API_KEY_HEADER],
 )
 
 

--- a/python/src/rest_api.py
+++ b/python/src/rest_api.py
@@ -247,7 +247,9 @@ def broadcast_tx_hex(tx: Tx, response: Response) -> Dict[str, Any]:
     transaction.deserialize(BytesIO(bytes))
     transaction.rehash()
     hash = transaction.hash
-    assert isinstance(hash, str)
+    if not isinstance(hash, str):
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return {"failure": "Failed to compute transaction hash"}
     # CTransaction
     if tx_analyser.tx_exist(hash):
         LOGGER.info("Transaction %s already exists", hash)
@@ -379,11 +381,6 @@ def add_monitor(monitor: Monitor, response: Response) -> Dict[str, Any]:
         response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
         return {
             "failed": f"Monitor name '{monitor.name}' already exists ",
-        }
-    if monitor.address is None and monitor.locking_script_pattern is None:
-        response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-        return {
-            "failed": f"Monitor is invalid '{monitor}'",
         }
     data = monitor.model_dump(mode='json')
     LOGGER.debug("Adding collection monitor: %s", data)

--- a/python/src/tx_analyser.py
+++ b/python/src/tx_analyser.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import List, Dict, Any, Optional
 
 from database import database
@@ -7,6 +8,8 @@ from merkle import create_merkle_branch
 from p2p_framework.object import CTransaction
 from config import ConfigType
 from mysql.connector.errors import ProgrammingError
+
+LOGGER = logging.getLogger(__name__)
 
 
 _TX_EXIST_QUERY = """
@@ -126,7 +129,7 @@ class TxAnalyser:
                 (hash,),
             )
         except ProgrammingError as e:
-            print(f"MySQL ProgrammingError {e}")
+            LOGGER.error("MySQL ProgrammingError: %s", e)
             return None
         try:
             return result[0]
@@ -195,7 +198,7 @@ class TxAnalyser:
         try:
             result = database.query(_TX_EXIST_QUERY, (hash, hash, hash))
         except ProgrammingError as e:
-            print(f"MySQL ProgrammingError {e}")
+            LOGGER.error("MySQL ProgrammingError: %s", e)
             result = database.query(_TX_EXIST_WITHOUT_TX_TABLE_QUERY, (hash, hash))
         return len(result) > 0
 
@@ -223,7 +226,7 @@ class TxAnalyser:
             )
             txs = [x[0] for x in result]
         except ProgrammingError as e:
-            print(f"MySQL ProgrammingError {e}")
+            LOGGER.error("MySQL ProgrammingError: %s", e)
             txs = []
 
         # Create merkle proof

--- a/python/src/web.py
+++ b/python/src/web.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+import logging
+
 import uvicorn
 
 from database import database
@@ -9,13 +11,27 @@ from logic import logic
 from config import load_config_or_exit, ConfigType
 from collection import collection
 
+LOGGER = logging.getLogger(__name__)
+
+LOCAL_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
 
 def run_webserver(config: ConfigType):
     """ Given the config run the webserver
     """
     address = config["address"]
     (host, port) = address.split(":")
-    print(f"host is set to: {host}")
+
+    # Warn loudly if the API is reachable off-host without authentication:
+    # the broadcast and collection-monitor endpoints mutate state.
+    if not config.get("api_key") and host not in LOCAL_HOSTS:
+        LOGGER.warning(
+            "SECURITY: binding to %s with no api_key set - tx broadcast and "
+            "monitor endpoints will be UNAUTHENTICATED. Set [web_interface].api_key "
+            "or bind to 127.0.0.1 behind a reverse proxy.",
+            host,
+        )
+    LOGGER.info("host is set to: %s", host)
 
     # Run as HTTP
     uvicorn.run(

--- a/rust/src/dynamic_config.rs
+++ b/rust/src/dynamic_config.rs
@@ -39,7 +39,7 @@ impl DynamicConfig {
         let collection = match read_dynamic_config(&filename) {
             Ok(clients) => clients,
             Err(e) => {
-                println!("Error reading dynamic config file {:?}", e);
+                log::error!("Error reading dynamic config file {:?}", e);
                 Vec::new()
             }
         };

--- a/rust/src/uaas/tx_analyser.rs
+++ b/rust/src/uaas/tx_analyser.rs
@@ -83,14 +83,14 @@ impl TxAnalyser {
         for c in &config.collection {
             match WorkingCollection::new(c.clone(), network) {
                 Ok(wc) => collection.push(wc),
-                Err(e) => println!("Error parsing collection {:?}", e),
+                Err(e) => log::error!("Error parsing collection {:?}", e),
             }
         }
         // load the dynamic collection
         for c in &dynamic_config.collection {
             match WorkingCollection::new(c.clone(), network) {
                 Ok(wc) => collection.push(wc),
-                Err(e) => println!("Error parsing collection {:?}", e),
+                Err(e) => log::error!("Error parsing collection {:?}", e),
             }
         }
         // Create a collection for broadcast txs
@@ -344,7 +344,7 @@ impl TxAnalyser {
                     // add to dynamic config
                     self.dynamic_config.add(&monitor);
                 }
-                Err(e) => println!("Error parsing collection {:?}", e),
+                Err(e) => log::error!("Error parsing collection {:?}", e),
             }
         }
     }
@@ -362,7 +362,7 @@ impl TxAnalyser {
                 Some(index) => {
                     self.collection.remove(index);
                 }
-                None => println!("Error indexing collection {}", monitor_name),
+                None => log::error!("Error indexing collection {}", monitor_name),
             }
             // Delete from dynamic config
             self.dynamic_config.delete(monitor_name);


### PR DESCRIPTION
## Summary
Addresses safe, high-value findings from the repo review.

**Python code-quality**
- Route DB/connection errors through `logging` instead of `print()` (collection, logic, tx_analyser, block_manager)
- Convert production `assert`s in collection.py to `ValueError` (asserts are stripped under `python -O`)
- Replace `assert isinstance` in broadcast handler with a 500 guard; remove dead duplicate validation block

**Security defaults**
- Narrow CORS from `["*"]` to methods/headers actually used
- Log a SECURITY warning when binding non-local with no api_key

**Secrets**
- Source `MARIADB_ROOT_PASSWORD` from `.env` (falls back to prior default); add `.env.example`; gitignore `.env`/keys/certs

**Rust**
- Collection/config parse errors `println!` → `log::error!`

## Deliberately deferred (need decisions / local build)
- `failed`/`failure` key inconsistency & `/health` error detail — locked in by tests (API contract)
- Least-privilege DB grants — app does its own DDL, so db-scoped GRANT ALL is close to required
- Rust lock-poison handling & orphan-queue cap — behavior-changing, need cargo build/test

## Verification
- `uv run pytest`: passing (confirmed locally)
- Rust: please run `cargo build && cargo clippy && cargo test`